### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .yardoc
 .ruby-version
 .env
-Gemfile.lock
 InstalledFiles
 _yardoc
 coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,96 @@
+PATH
+  remote: .
+  specs:
+    braze_ruby (0.0.2)
+      faraday
+      faraday_middleware
+      virtus
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
+    concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
+    diff-lcs (1.3)
+    dotenv (2.7.1)
+    equalizer (0.0.11)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
+    hashdiff (0.3.8)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    method_source (0.9.2)
+    minitest (5.11.3)
+    multipart-post (2.0.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    public_suffix (3.0.3)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    safe_yaml (1.0.5)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    vcr (4.0.0)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
+    webmock (3.5.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  braze_ruby!
+  bundler (>= 1.3)
+  dotenv
+  factory_bot
+  pry
+  rake
+  rspec
+  vcr
+  webmock
+
+BUNDLED WITH
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     braze_ruby (0.0.2)
       faraday
       faraday_middleware
-      virtus
 
 GEM
   remote: https://rubygems.org/
@@ -16,21 +15,12 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
-    axiom-types (0.1.1)
-      descendants_tracker (~> 0.0.4)
-      ice_nine (~> 0.11.0)
-      thread_safe (~> 0.3, >= 0.3.1)
     coderay (1.1.2)
-    coercible (1.0.0)
-      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
     dotenv (2.7.1)
-    equalizer (0.0.11)
     factory_bot (5.0.2)
       activesupport (>= 4.2.0)
     faraday (0.15.4)
@@ -40,7 +30,6 @@ GEM
     hashdiff (0.3.8)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
-    ice_nine (0.11.2)
     method_source (0.9.2)
     minitest (5.11.3)
     multipart-post (2.0.0)
@@ -67,11 +56,6 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     vcr (4.0.0)
-    virtus (1.0.5)
-      axiom-types (~> 0.1)
-      coercible (~> 1.0)
-      descendants_tracker (~> 0.0, >= 0.0.3)
-      equalizer (~> 0.0, >= 0.0.9)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)

--- a/braze_ruby.gemspec
+++ b/braze_ruby.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'virtus'
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware'
   spec.add_development_dependency 'bundler', '>= 1.3'

--- a/braze_ruby.gemspec
+++ b/braze_ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'virtus'
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday_middleware'
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'dotenv'

--- a/lib/braze_ruby.rb
+++ b/lib/braze_ruby.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'virtus'
 require 'braze_ruby/version'
 
 module BrazeRuby

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,35 +1,35 @@
 FactoryBot.define do
   factory :attribute, class: Hash do
     skip_create
-    external_id 1
-    foo :bar
+    external_id { 1 }
+    foo { :bar }
 
     initialize_with { attributes }
   end
 
   factory :event, class: Hash do
     skip_create
-    external_id 1
-    name :baz
-    time Time.now
+    external_id { 1 }
+    name { :baz }
+    time { Time.now }
 
     initialize_with { attributes }
   end
 
   factory :purchase, class: Hash do
     skip_create
-    external_id 1
-    product_id 1
-    time Time.now
-    currency 'CAD'
-    price 1.0
+    external_id { 1 }
+    product_id { 1 }
+    time { Time.now }
+    currency { 'CAD' }
+    price { 1.0 }
 
     initialize_with { attributes }
   end
 
   factory :messages, class: Hash do
     skip_create
-    apple_push({ alert: :hello })
+    apple_push { {alert: :hello} }
 
     initialize_with { attributes }
   end

--- a/spec/fixtures/responses/delete_users/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/delete_users/with_success/responds_with_created.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/delete"
     body:
       encoding: UTF-8
-      string: '{"api_key":"839aaeba-c8f1-4b46-b511-67ad03558e82","external_ids":[400,401,402]}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_ids":[400,401,402]}'
     headers:
       User-Agent:
       - Faraday v0.14.0
@@ -64,6 +64,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"invalid_user_ids":[400,401,402],"deleted":3,"message":"success"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 18 May 2018 18:54:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/responses/delete_users/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/delete_users/with_success/responds_with_success_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/delete"
     body:
       encoding: UTF-8
-      string: '{"api_key":"839aaeba-c8f1-4b46-b511-67ad03558e82","external_ids":[400,401,402]}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_ids":[400,401,402]}'
     headers:
       User-Agent:
       - Faraday v0.14.0
@@ -64,6 +64,6 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: '{"invalid_user_ids":[400,401,402],"deleted":0,"message":"success"}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 18 May 2018 18:54:14 GMT
 recorded_with: VCR 4.0.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,11 +16,11 @@ RSpec.configure do |config|
   end
 
   def braze_rest_api_key
-    'test'
+    ENV.fetch('BRAZE_REST_API_KEY', 'test')
   end
 
   def braze_rest_url
-    'https://rest.iad-03.braze.com'
+    ENV.fetch('BRAZE_REST_URL', 'https://rest.iad-03.braze.com')
   end
 
   def braze_test_segment

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,10 +1,10 @@
 require 'factory_bot'
-require 'factories'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.before(:suite) do
+    FactoryBot.find_definitions
     FactoryBot.lint
   end
 end


### PR DESCRIPTION
* Unlock bundler version to be able to test with modern one
* Update Factory Bot syntax to define attributes within block
* Fix Factory Bot factories initiralization
* Fix passing api key/url from ENV variables
* Remove API key recorded in the spec cassette
* Remove unused virtus gem

Also add Gemfile.lock to repo
Read more on https://bundler.io/guides/faq.html#committing-lockfiles-in-libraries