### PR TITLE
Relax faraday dependency, older versions are compatible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     braze_ruby (0.3.1)
-      faraday (~> 0.17.1)
+      faraday
 
 GEM
   remote: https://rubygems.org/

--- a/braze_ruby.gemspec
+++ b/braze_ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.0'
 
-  spec.add_dependency 'faraday', '~> 0.17.1'
+  spec.add_dependency 'faraday'
 
   spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'rake', '~> 12.3.3'

--- a/lib/braze_ruby/version.rb
+++ b/lib/braze_ruby/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrazeRuby
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
We have recently started using the `braze_ruby` gem for our integration (thanks much, it has been very helpful!!). A [recent change](https://github.com/jboltz88/braze_ruby/pull/10/files#diff-dddd2dc710aa239ce4989a7ec9971a6fR28) pinned faraday to require v0.17.1 or above, which would force us down a difficult upgrade path for some of our other dependencies. As far as I can tell, there is nothing requiring this high a version of Faraday, so this relaxes the requirement so it is, again, compatible in our stack.

We considered forking and making this change internally, but we're also expecting we may want to add support for a few other endpoints soon and would rather be able to contribute back. Let me know if you have any questions or concerns!