### PR TITLE
Add ability to set Faraday request options

### DIFF
--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -27,18 +27,19 @@ module BrazeRuby
     include BrazeRuby::Endpoints::IdentifyUsers
 
     def export_users(**payload)
-      BrazeRuby::REST::ExportUsers.new(braze_url).perform(api_key, payload)
+      BrazeRuby::REST::ExportUsers.new(braze_url, options).perform(api_key, payload)
     end
 
     def list_segments
-      BrazeRuby::REST::ListSegments.new(braze_url).perform(api_key)
+      BrazeRuby::REST::ListSegments.new(braze_url, options).perform(api_key)
     end
 
-    attr_reader :api_key, :braze_url
+    attr_reader :api_key, :braze_url, :options
 
-    def initialize(api_key, braze_url)
+    def initialize(api_key, braze_url, options = {})
       @api_key = api_key
       @braze_url = braze_url
+      @options = options
     end
   end
 end

--- a/lib/braze_ruby/endpoints/campaigns.rb
+++ b/lib/braze_ruby/endpoints/campaigns.rb
@@ -4,7 +4,7 @@ module BrazeRuby
   module Endpoints
     module Campaigns
       def trigger_campaign_send(**payload)
-        BrazeRuby::REST::TriggerCampaignSend.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::TriggerCampaignSend.new(api_key, braze_url, options, payload).perform
       end
     end
   end

--- a/lib/braze_ruby/endpoints/canvas.rb
+++ b/lib/braze_ruby/endpoints/canvas.rb
@@ -4,11 +4,11 @@ module BrazeRuby
   module Endpoints
     module Canvas
       def trigger_canvas_send(**payload)
-        BrazeRuby::REST::TriggerCanvasSend.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::TriggerCanvasSend.new(api_key, braze_url, options, payload).perform
       end
 
       def canvas_details(**payload)
-        BrazeRuby::REST::CanvasDetails.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::CanvasDetails.new(api_key, braze_url, options, payload).perform
       end
     end
   end

--- a/lib/braze_ruby/endpoints/delete_users.rb
+++ b/lib/braze_ruby/endpoints/delete_users.rb
@@ -16,7 +16,7 @@ module BrazeRuby
       private
 
       def delete_users_service
-        @delete_users_service ||= BrazeRuby::REST::DeleteUsers.new(braze_url)
+        @delete_users_service ||= BrazeRuby::REST::DeleteUsers.new(braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/endpoints/email_status.rb
+++ b/lib/braze_ruby/endpoints/email_status.rb
@@ -4,7 +4,7 @@ module BrazeRuby
   module Endpoints
     module EmailStatus
       def email_status(**payload)
-        email_status_service.new(api_key, braze_url, payload).perform
+        email_status_service.new(api_key, braze_url, options, payload).perform
       end
 
       def email_status_service

--- a/lib/braze_ruby/endpoints/email_sync.rb
+++ b/lib/braze_ruby/endpoints/email_sync.rb
@@ -4,11 +4,11 @@ module BrazeRuby
   module Endpoints
     module EmailSync
       def email_unsubscribes(**payload)
-        BrazeRuby::REST::EmailUnsubscribes.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::EmailUnsubscribes.new(api_key, braze_url, options, payload).perform
       end
 
       def email_hard_bounces(**payload)
-        BrazeRuby::REST::EmailHardBounces.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::EmailHardBounces.new(api_key, braze_url, options, payload).perform
       end
     end
   end

--- a/lib/braze_ruby/endpoints/identify_users.rb
+++ b/lib/braze_ruby/endpoints/identify_users.rb
@@ -12,7 +12,7 @@ module BrazeRuby
       private
 
       def identify_users_service
-        @identify_users_service ||= BrazeRuby::REST::IdentifyUsers.new(braze_url)
+        @identify_users_service ||= BrazeRuby::REST::IdentifyUsers.new(braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/endpoints/schedule_messages.rb
+++ b/lib/braze_ruby/endpoints/schedule_messages.rb
@@ -4,7 +4,7 @@ module BrazeRuby
   module Endpoints
     module ScheduleMessages
       def schedule_messages(**payload)
-        schedule_messages_service.new(api_key, braze_url, payload).perform
+        schedule_messages_service.new(api_key, braze_url, options, payload).perform
       end
 
       private

--- a/lib/braze_ruby/endpoints/send_messages.rb
+++ b/lib/braze_ruby/endpoints/send_messages.rb
@@ -4,7 +4,7 @@ module BrazeRuby
   module Endpoints
     module SendMessages
       def send_messages(**payload)
-        send_messages_service.new(api_key, braze_url, payload).perform
+        send_messages_service.new(api_key, braze_url, options, payload).perform
       end
 
       private

--- a/lib/braze_ruby/endpoints/subscription.rb
+++ b/lib/braze_ruby/endpoints/subscription.rb
@@ -4,16 +4,16 @@ module BrazeRuby
   module Endpoints
     module Subscription
       def subscription_status_set(**payload)
-        BrazeRuby::REST::SubscriptionStatusSet.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::SubscriptionStatusSet.new(api_key, braze_url, options, payload).perform
       end
 
       def subscription_status_get(**payload)
-        BrazeRuby::REST::SubscriptionStatusGet.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::SubscriptionStatusGet.new(api_key, braze_url, options, payload).perform
       end
 
 
       def subscription_user_status(**payload)
-        BrazeRuby::REST::SubscriptionUserStatus.new(api_key, braze_url, payload).perform
+        BrazeRuby::REST::SubscriptionUserStatus.new(api_key, braze_url, options, payload).perform
       end
     end
   end

--- a/lib/braze_ruby/endpoints/track_users.rb
+++ b/lib/braze_ruby/endpoints/track_users.rb
@@ -24,7 +24,7 @@ module BrazeRuby
       private
 
       def track_users_service
-        @track_users_service ||= BrazeRuby::REST::TrackUsers.new(braze_url)
+        @track_users_service ||= BrazeRuby::REST::TrackUsers.new(braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/http.rb
+++ b/lib/braze_ruby/http.rb
@@ -5,8 +5,11 @@ require 'faraday'
 
 module BrazeRuby
   class HTTP
-    def initialize(braze_url)
+    DEFAULT_TIMEOUT = 30
+
+    def initialize(braze_url, options = {})
       @braze_url = braze_url
+      @options = default_options.merge(options)
     end
 
     def post(path, payload)
@@ -28,7 +31,15 @@ module BrazeRuby
         connection.response :logger if ENV['BRAZE_RUBY_DEBUG']
 
         connection.adapter Faraday.default_adapter
+
+        connection.options[:timeout] = @options[:timeout]
       end
+    end
+
+    private
+
+    def default_options
+      {timeout: DEFAULT_TIMEOUT}
     end
   end
 end

--- a/lib/braze_ruby/rest/base.rb
+++ b/lib/braze_ruby/rest/base.rb
@@ -7,14 +7,15 @@ module BrazeRuby
     class Base
       attr_writer :http
 
-      def initialize(braze_url)
+      def initialize(braze_url, options)
         @braze_url = braze_url
+        @options = options
       end
 
       private
 
       def http
-        @http ||= BrazeRuby::HTTP.new(@braze_url)
+        @http ||= BrazeRuby::HTTP.new(@braze_url, @options)
       end
     end
   end

--- a/lib/braze_ruby/rest/canvas_details.rb
+++ b/lib/braze_ruby/rest/canvas_details.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class CanvasDetails < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/email_hard_bounces.rb
+++ b/lib/braze_ruby/rest/email_hard_bounces.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class EmailHardBounces < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/email_status.rb
+++ b/lib/braze_ruby/rest/email_status.rb
@@ -5,11 +5,11 @@ module BrazeRuby
     class EmailStatus < Base
       attr_reader :api_key, :email, :status
 
-      def initialize(api_key, braze_url, email: nil, status: nil)
+      def initialize(api_key, braze_url, options, email: nil, status: nil)
         @api_key = api_key
         @email = email
         @status = status
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/email_unsubscribes.rb
+++ b/lib/braze_ruby/rest/email_unsubscribes.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class EmailUnsubscribes < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/schedule_messages.rb
+++ b/lib/braze_ruby/rest/schedule_messages.rb
@@ -5,13 +5,13 @@ module BrazeRuby
     class ScheduleMessages < Base
       attr_reader :api_key, :time, :messages, :in_local_time, :external_user_ids
 
-      def initialize(api_key, braze_url, time: nil, messages: [], external_user_ids: [], in_local_time: false)
+      def initialize(api_key, braze_url, options, time: nil, messages: [], external_user_ids: [], in_local_time: false)
         @api_key = api_key
         @messages = messages
         @time = time
         @external_user_ids = external_user_ids
         @in_local_time = in_local_time
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/send_messages.rb
+++ b/lib/braze_ruby/rest/send_messages.rb
@@ -5,11 +5,11 @@ module BrazeRuby
     class SendMessages < Base
       attr_reader :api_key, :messages, :external_user_ids
 
-      def initialize(api_key, braze_url, messages: [], external_user_ids: [])
+      def initialize(api_key, braze_url, options, messages: [], external_user_ids: [])
         @api_key = api_key
         @messages = messages
         @external_user_ids = external_user_ids
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/subscription_status_get.rb
+++ b/lib/braze_ruby/rest/subscription_status_get.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class SubscriptionStatusGet < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/subscription_status_set.rb
+++ b/lib/braze_ruby/rest/subscription_status_set.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class SubscriptionStatusSet < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/subscription_user_status.rb
+++ b/lib/braze_ruby/rest/subscription_user_status.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class SubscriptionUserStatus < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/trigger_campaign_send.rb
+++ b/lib/braze_ruby/rest/trigger_campaign_send.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class TriggerCampaignSend < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/trigger_canvas_send.rb
+++ b/lib/braze_ruby/rest/trigger_canvas_send.rb
@@ -5,10 +5,10 @@ module BrazeRuby
     class TriggerCanvasSend < Base
       attr_reader :api_key, :params
 
-      def initialize(api_key, braze_url, **params)
+      def initialize(api_key, braze_url, options, **params)
         @api_key = api_key
         @params = params
-        super braze_url
+        super braze_url, options
       end
 
       def perform

--- a/spec/braze_ruby/http_spec.rb
+++ b/spec/braze_ruby/http_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'braze_ruby/http'
+
+describe BrazeRuby::HTTP do
+  describe "#connection" do
+    let(:options) { double("options", :"[]=" => nil) }
+    let(:headers) { double("headers", :"[]=" => nil) }
+    let(:conn) { double("conn", adapter: nil, options: options, headers: headers) }
+
+    before :each do
+      allow(Faraday).to receive(:new).and_yield(conn)
+      allow(Faraday).to receive(:default_adapter).and_return(:default_adapter)
+    end
+
+    it "it defaults to the timeout option" do
+      described_class.new("http://example.com").connection
+
+      expect(options).to have_received(:"[]=").with(:timeout, described_class::DEFAULT_TIMEOUT)
+    end
+
+    it "it sets the default timeout option when given" do
+      timeout = 5
+      described_class.new("http://example.com", {timeout: timeout}).connection
+
+      expect(options).to have_received(:"[]=").with(:timeout, timeout)
+    end
+
+    it "sets the headers" do
+      described_class.new("http://example.com").connection
+
+
+      expect(headers).to have_received(:"[]=").with("Content-Type", "application/json")
+      expect(headers).to have_received(:"[]=").with("Accept", "application/json")
+      expect(headers).to have_received(:"[]=").with("User-Agent", "Braze Ruby gem v#{BrazeRuby::VERSION}")
+    end
+
+    it "it sets the default adapter" do
+      described_class.new("http://example.com").connection
+
+      expect(conn).to have_received(:adapter).with(:default_adapter)
+    end
+  end
+end

--- a/spec/braze_ruby/rest/delete_users_spec.rb
+++ b/spec/braze_ruby/rest/delete_users_spec.rb
@@ -9,7 +9,7 @@ describe BrazeRuby::REST::DeleteUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url}
+  subject { described_class.new :rest_url, {}}
 
   before { subject.http = http }
 

--- a/spec/braze_ruby/rest/email_status_spec.rb
+++ b/spec/braze_ruby/rest/email_status_spec.rb
@@ -7,7 +7,7 @@ describe BrazeRuby::REST::EmailStatus do
 
   before { subject.http = http }
 
-  subject { described_class.new(:api_key, :rest_url, email: :email, status: :status) }
+  subject { described_class.new(:api_key, :rest_url, {}, email: :email, status: :status) }
 
   it 'makes an http call to the email status endpoint' do
     expect(http).to receive(:post).with '/email/status', {

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -8,7 +8,7 @@ describe BrazeRuby::REST::ExportUsers do
   let(:payload) {{ external_ids: external_ids }}
   let(:external_ids) { [1] }
 
-  subject { described_class.new :rest_url }
+  subject { described_class.new :rest_url, {} }
 
   before { subject.http = http }
 

--- a/spec/braze_ruby/rest/identify_users_spec.rb
+++ b/spec/braze_ruby/rest/identify_users_spec.rb
@@ -10,7 +10,7 @@ describe BrazeRuby::REST::IdentifyUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url}
+  subject { described_class.new :rest_url, {}}
 
   before { subject.http = http }
 

--- a/spec/braze_ruby/rest/schedule_messages_spec.rb
+++ b/spec/braze_ruby/rest/schedule_messages_spec.rb
@@ -14,7 +14,7 @@ describe BrazeRuby::REST::ScheduleMessages do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new(api_key, :rest_url, payload) }
+  subject { described_class.new(api_key, :rest_url, {}, payload) }
 
   before { subject.http = http }
 

--- a/spec/braze_ruby/rest/send_messages_spec.rb
+++ b/spec/braze_ruby/rest/send_messages_spec.rb
@@ -12,7 +12,9 @@ describe BrazeRuby::REST::SendMessages do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new(api_key,
+  subject { described_class.new(
+    api_key,
+    {},
     messages: :messages,
     external_user_ids: :external_user_ids
   ) }

--- a/spec/braze_ruby/rest/track_users_spec.rb
+++ b/spec/braze_ruby/rest/track_users_spec.rb
@@ -13,7 +13,7 @@ describe BrazeRuby::REST::TrackUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url}
+  subject { described_class.new :rest_url, {}}
 
   before { subject.http = http }
 

--- a/spec/support/integrations.rb
+++ b/spec/support/integrations.rb
@@ -13,8 +13,12 @@ module Integrations
     braze_test_segment
   end
 
+  def options
+    {}
+  end
+
   def api
-    BrazeRuby::API.new(api_key, rest_url)
+    BrazeRuby::API.new(api_key, rest_url, options)
   end
 
   RSpec.configure do |config|


### PR DESCRIPTION
We would like to add a timeout to the Faraday requests. This adds a default timeout of 30 seconds with the ability to override it by passing in a map.