### PR TITLE
pass api_key as Authorization header

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    braze_ruby (0.3.2)
+    braze_ruby (0.3.3)
       faraday
 
 GEM
@@ -23,7 +23,7 @@ GEM
     dotenv (2.7.5)
     factory_bot (5.1.0)
       activesupport (>= 4.2.0)
-    faraday (0.17.1)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     hashdiff (1.0.0)
     i18n (1.6.0)

--- a/lib/braze_ruby/api.rb
+++ b/lib/braze_ruby/api.rb
@@ -27,11 +27,11 @@ module BrazeRuby
     include BrazeRuby::Endpoints::IdentifyUsers
 
     def export_users(**payload)
-      BrazeRuby::REST::ExportUsers.new(braze_url, options).perform(api_key, payload)
+      BrazeRuby::REST::ExportUsers.new(api_key, braze_url, options).perform(**payload)
     end
 
     def list_segments
-      BrazeRuby::REST::ListSegments.new(braze_url, options).perform(api_key)
+      BrazeRuby::REST::ListSegments.new(api_key, braze_url, options).perform
     end
 
     attr_reader :api_key, :braze_url, :options

--- a/lib/braze_ruby/endpoints/delete_users.rb
+++ b/lib/braze_ruby/endpoints/delete_users.rb
@@ -6,7 +6,7 @@ module BrazeRuby
       attr_writer :delete_users_service
 
       def delete_users_action(**payload)
-        delete_users_service.perform(api_key, payload)
+        delete_users_service.perform(payload)
       end
 
       def delete_users(payload)
@@ -16,7 +16,7 @@ module BrazeRuby
       private
 
       def delete_users_service
-        @delete_users_service ||= BrazeRuby::REST::DeleteUsers.new(braze_url, options)
+        @delete_users_service ||= BrazeRuby::REST::DeleteUsers.new(api_key, braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/endpoints/identify_users.rb
+++ b/lib/braze_ruby/endpoints/identify_users.rb
@@ -6,13 +6,13 @@ module BrazeRuby
       attr_writer :identify_users_service
 
       def identify_users(**payload)
-        identify_users_service.perform(api_key, payload)
+        identify_users_service.perform(payload)
       end
 
       private
 
       def identify_users_service
-        @identify_users_service ||= BrazeRuby::REST::IdentifyUsers.new(braze_url, options)
+        @identify_users_service ||= BrazeRuby::REST::IdentifyUsers.new(api_key, braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/endpoints/track_users.rb
+++ b/lib/braze_ruby/endpoints/track_users.rb
@@ -6,7 +6,7 @@ module BrazeRuby
       attr_writer :track_users_service
 
       def track_users(**payload)
-        track_users_service.perform(api_key, payload)
+        track_users_service.perform(payload)
       end
 
       def track_purchase(payload)
@@ -24,7 +24,7 @@ module BrazeRuby
       private
 
       def track_users_service
-        @track_users_service ||= BrazeRuby::REST::TrackUsers.new(braze_url, options)
+        @track_users_service ||= BrazeRuby::REST::TrackUsers.new(api_key, braze_url, options)
       end
     end
   end

--- a/lib/braze_ruby/http.rb
+++ b/lib/braze_ruby/http.rb
@@ -7,9 +7,10 @@ module BrazeRuby
   class HTTP
     DEFAULT_TIMEOUT = 30
 
-    def initialize(braze_url, options = {})
+    def initialize(api_key, braze_url, options = {})
+      @api_key   = api_key
       @braze_url = braze_url
-      @options = default_options.merge(options)
+      @options   = default_options.merge(options)
     end
 
     def post(path, payload)
@@ -18,15 +19,16 @@ module BrazeRuby
       end
     end
 
-    def get(path, query)
+    def get(path, query = {})
       connection.get path, query
     end
 
     def connection
       @connection ||= Faraday.new(url: @braze_url) do |connection|
-        connection.headers['Content-Type'] = 'application/json'
-        connection.headers['Accept']       = 'application/json'
-        connection.headers['User-Agent']   = "Braze Ruby gem v#{BrazeRuby::VERSION}"
+        connection.headers["Content-Type"]  = "application/json"
+        connection.headers["Accept"]        = "application/json"
+        connection.headers["User-Agent"]    = "Braze Ruby gem v#{BrazeRuby::VERSION}"
+        connection.headers["Authorization"] = "Bearer #{@api_key}"
 
         connection.response :logger if ENV['BRAZE_RUBY_DEBUG']
 

--- a/lib/braze_ruby/rest/base.rb
+++ b/lib/braze_ruby/rest/base.rb
@@ -7,15 +7,16 @@ module BrazeRuby
     class Base
       attr_writer :http
 
-      def initialize(braze_url, options)
+      def initialize(api_key, braze_url, options)
+        @api_key   = api_key
         @braze_url = braze_url
-        @options = options
+        @options   = options
       end
 
       private
 
       def http
-        @http ||= BrazeRuby::HTTP.new(@braze_url, @options)
+        @http ||= BrazeRuby::HTTP.new(@api_key, @braze_url, @options)
       end
     end
   end

--- a/lib/braze_ruby/rest/canvas_details.rb
+++ b/lib/braze_ruby/rest/canvas_details.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class CanvasDetails < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/lib/braze_ruby/rest/canvas_details.rb
+++ b/lib/braze_ruby/rest/canvas_details.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.get('/canvas/details', {
-          'api_key': api_key,
           **@params
         })
       end

--- a/lib/braze_ruby/rest/delete_users.rb
+++ b/lib/braze_ruby/rest/delete_users.rb
@@ -3,9 +3,8 @@
 module BrazeRuby
   module REST
     class DeleteUsers < Base
-      def perform(api_key, external_ids: [])
+      def perform(external_ids: [])
         http.post '/users/delete', {
-          'api_key':        api_key,
           'external_ids':   external_ids
         }
       end

--- a/lib/braze_ruby/rest/email_hard_bounces.rb
+++ b/lib/braze_ruby/rest/email_hard_bounces.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class EmailHardBounces < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/lib/braze_ruby/rest/email_hard_bounces.rb
+++ b/lib/braze_ruby/rest/email_hard_bounces.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.get('/email/hard_bounces', {
-          'api_key': api_key,
           **@params
         })
       end

--- a/lib/braze_ruby/rest/email_status.rb
+++ b/lib/braze_ruby/rest/email_status.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class EmailStatus < Base
-      attr_reader :api_key, :email, :status
+      attr_reader :email, :status
 
       def initialize(api_key, braze_url, options, email: nil, status: nil)
         @email = email
@@ -13,7 +13,6 @@ module BrazeRuby
 
       def perform
         http.post '/email/status', {
-          'api_key': api_key,
           'email': email,
           'subscription_state': status
         }

--- a/lib/braze_ruby/rest/email_status.rb
+++ b/lib/braze_ruby/rest/email_status.rb
@@ -6,10 +6,9 @@ module BrazeRuby
       attr_reader :api_key, :email, :status
 
       def initialize(api_key, braze_url, options, email: nil, status: nil)
-        @api_key = api_key
         @email = email
         @status = status
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/email_unsubscribes.rb
+++ b/lib/braze_ruby/rest/email_unsubscribes.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.get('/email/unsubscribes', {
-          'api_key': api_key,
           **params
         })
       end

--- a/lib/braze_ruby/rest/email_unsubscribes.rb
+++ b/lib/braze_ruby/rest/email_unsubscribes.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class EmailUnsubscribes < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/lib/braze_ruby/rest/export_users.rb
+++ b/lib/braze_ruby/rest/export_users.rb
@@ -3,24 +3,22 @@
 module BrazeRuby
   module REST
     class ExportUsers < Base
-      def perform(api_key, external_ids: nil, segment_id: nil, **options)
-        return export_users_by_ids(api_key, external_ids) if external_ids
+      def perform(external_ids: nil, segment_id: nil, **options)
+        return export_users_by_ids(external_ids) if external_ids
 
-        export_users_by_segment(api_key, segment_id, options) if segment_id
+        export_users_by_segment(segment_id, options) if segment_id
       end
 
       private
 
-      def export_users_by_ids(api_key, external_ids)
+      def export_users_by_ids(external_ids)
         http.post '/users/export/ids', {
-          'api_key': api_key,
           'external_ids': external_ids
         }
       end
 
-      def export_users_by_segment(api_key, segment_id, options)
+      def export_users_by_segment(segment_id, options)
         http.post '/users/export/segment', {
-          'api_key': api_key,
           'segment_id': segment_id
         }.merge(options)
       end

--- a/lib/braze_ruby/rest/identify_users.rb
+++ b/lib/braze_ruby/rest/identify_users.rb
@@ -3,10 +3,9 @@
 module BrazeRuby
   module REST
     class IdentifyUsers < Base
-      def perform(api_key, aliases_to_identify: [])
+      def perform(aliases_to_identify: [])
         http.post '/users/identify', {
-          'api_key':             api_key,
-          'aliases_to_identify': aliases_to_identify,
+          'aliases_to_identify': aliases_to_identify
         }
       end
     end

--- a/lib/braze_ruby/rest/list_segments.rb
+++ b/lib/braze_ruby/rest/list_segments.rb
@@ -3,10 +3,8 @@
 module BrazeRuby
   module REST
     class ListSegments < Base
-      def perform(api_key)
-        http.get '/segments/list', {
-          'api_key': api_key
-        }
+      def perform
+        http.get '/segments/list'
       end
     end
   end

--- a/lib/braze_ruby/rest/schedule_messages.rb
+++ b/lib/braze_ruby/rest/schedule_messages.rb
@@ -6,17 +6,15 @@ module BrazeRuby
       attr_reader :api_key, :time, :messages, :in_local_time, :external_user_ids
 
       def initialize(api_key, braze_url, options, time: nil, messages: [], external_user_ids: [], in_local_time: false)
-        @api_key = api_key
         @messages = messages
         @time = time
         @external_user_ids = external_user_ids
         @in_local_time = in_local_time
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.post '/messages/schedule/create', {
-          'api_key':                    api_key,
           'external_user_ids':          external_user_ids,
           'schedule': {
             'time':                       time,

--- a/lib/braze_ruby/rest/schedule_messages.rb
+++ b/lib/braze_ruby/rest/schedule_messages.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class ScheduleMessages < Base
-      attr_reader :api_key, :time, :messages, :in_local_time, :external_user_ids
+      attr_reader :time, :messages, :in_local_time, :external_user_ids
 
       def initialize(api_key, braze_url, options, time: nil, messages: [], external_user_ids: [], in_local_time: false)
         @messages = messages

--- a/lib/braze_ruby/rest/send_messages.rb
+++ b/lib/braze_ruby/rest/send_messages.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class SendMessages < Base
-      attr_reader :api_key, :messages, :external_user_ids
+      attr_reader :messages, :external_user_ids
 
       def initialize(api_key, braze_url, options, messages: [], external_user_ids: [])
         @messages = messages

--- a/lib/braze_ruby/rest/send_messages.rb
+++ b/lib/braze_ruby/rest/send_messages.rb
@@ -6,15 +6,13 @@ module BrazeRuby
       attr_reader :api_key, :messages, :external_user_ids
 
       def initialize(api_key, braze_url, options, messages: [], external_user_ids: [])
-        @api_key = api_key
         @messages = messages
         @external_user_ids = external_user_ids
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.post '/messages/send', {
-          'api_key':           api_key,
           'messages':          messages,
           'external_user_ids': external_user_ids
         }

--- a/lib/braze_ruby/rest/subscription_status_get.rb
+++ b/lib/braze_ruby/rest/subscription_status_get.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class SubscriptionStatusGet < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params
@@ -12,7 +12,6 @@ module BrazeRuby
 
       def perform
         http.get('/subscription/status/get', {
-          'api_key': api_key,
           **params
         })
       end

--- a/lib/braze_ruby/rest/subscription_status_get.rb
+++ b/lib/braze_ruby/rest/subscription_status_get.rb
@@ -6,9 +6,8 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/subscription_status_set.rb
+++ b/lib/braze_ruby/rest/subscription_status_set.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class SubscriptionStatusSet < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params
@@ -12,7 +12,6 @@ module BrazeRuby
 
       def perform
         http.post('/subscription/status/set', {
-          'api_key': api_key,
           **params
         })
       end

--- a/lib/braze_ruby/rest/subscription_status_set.rb
+++ b/lib/braze_ruby/rest/subscription_status_set.rb
@@ -6,9 +6,8 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform

--- a/lib/braze_ruby/rest/subscription_user_status.rb
+++ b/lib/braze_ruby/rest/subscription_user_status.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.get('/subscription/user/status', {
-          'api_key': api_key,
           **params
         })
       end

--- a/lib/braze_ruby/rest/subscription_user_status.rb
+++ b/lib/braze_ruby/rest/subscription_user_status.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class SubscriptionUserStatus < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/lib/braze_ruby/rest/track_users.rb
+++ b/lib/braze_ruby/rest/track_users.rb
@@ -3,9 +3,8 @@
 module BrazeRuby
   module REST
     class TrackUsers < Base
-      def perform(api_key, attributes: [], events: [], purchases: [])
+      def perform(attributes: [], events: [], purchases: [])
         http.post '/users/track', {
-          'api_key':        api_key,
           'attributes':     attributes,
           'events':         events,
           'purchases':      purchases

--- a/lib/braze_ruby/rest/trigger_campaign_send.rb
+++ b/lib/braze_ruby/rest/trigger_campaign_send.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.post('/campaigns/trigger/send', {
-          'api_key': api_key,
           **@params
         })
       end

--- a/lib/braze_ruby/rest/trigger_campaign_send.rb
+++ b/lib/braze_ruby/rest/trigger_campaign_send.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class TriggerCampaignSend < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/lib/braze_ruby/rest/trigger_canvas_send.rb
+++ b/lib/braze_ruby/rest/trigger_canvas_send.rb
@@ -6,14 +6,12 @@ module BrazeRuby
       attr_reader :api_key, :params
 
       def initialize(api_key, braze_url, options, **params)
-        @api_key = api_key
         @params = params
-        super braze_url, options
+        super api_key, braze_url, options
       end
 
       def perform
         http.post('/canvas/trigger/send', {
-          'api_key': api_key,
           **@params
         })
       end

--- a/lib/braze_ruby/rest/trigger_canvas_send.rb
+++ b/lib/braze_ruby/rest/trigger_canvas_send.rb
@@ -3,7 +3,7 @@
 module BrazeRuby
   module REST
     class TriggerCanvasSend < Base
-      attr_reader :api_key, :params
+      attr_reader :params
 
       def initialize(api_key, braze_url, options, **params)
         @params = params

--- a/spec/braze_ruby/endpoints/delete_users_spec.rb
+++ b/spec/braze_ruby/endpoints/delete_users_spec.rb
@@ -23,7 +23,7 @@ describe BrazeRuby::Endpoints::DeleteUsers do
 
     it 'deletes users' do
       expect(delete_users_service).to receive(:perform)
-        .with(:api_key, external_ids: payload)
+        .with(external_ids: payload)
 
       delete_users!
     end

--- a/spec/braze_ruby/endpoints/track_users_spec.rb
+++ b/spec/braze_ruby/endpoints/track_users_spec.rb
@@ -27,7 +27,7 @@ describe BrazeRuby::Endpoints::TrackUsers do
 
     it 'tracks attributes, events and purchases' do
       expect(track_users_service).to receive(:perform)
-        .with(:api_key, payload)
+        .with(payload)
 
       track_users!
     end
@@ -40,7 +40,7 @@ describe BrazeRuby::Endpoints::TrackUsers do
 
     it 'tracks a single purchase' do
       expect(track_users_service).to receive(:perform)
-        .with(:api_key, purchases: [payload])
+        .with(purchases: [payload])
 
       track_purchase!
     end
@@ -53,7 +53,7 @@ describe BrazeRuby::Endpoints::TrackUsers do
 
     it 'tracks a single purchase' do
       expect(track_users_service).to receive(:perform)
-        .with(:api_key, events: [payload])
+        .with(events: [payload])
 
       track_event!
     end
@@ -66,7 +66,7 @@ describe BrazeRuby::Endpoints::TrackUsers do
 
     it 'tracks a single purchase' do
       expect(track_users_service).to receive(:perform)
-          .with(:api_key, attributes: [payload])
+          .with(attributes: [payload])
 
       track_attribute!
     end

--- a/spec/braze_ruby/http_spec.rb
+++ b/spec/braze_ruby/http_spec.rb
@@ -8,6 +8,8 @@ describe BrazeRuby::HTTP do
     let(:options) { double("options", :"[]=" => nil) }
     let(:headers) { double("headers", :"[]=" => nil) }
     let(:conn) { double("conn", adapter: nil, options: options, headers: headers) }
+    let(:api_key) { "braze-api-key" }
+    let(:braze_url) { "http://example.com" }
 
     before :each do
       allow(Faraday).to receive(:new).and_yield(conn)
@@ -15,29 +17,30 @@ describe BrazeRuby::HTTP do
     end
 
     it "it defaults to the timeout option" do
-      described_class.new("http://example.com").connection
+      described_class.new(api_key, braze_url).connection
 
       expect(options).to have_received(:"[]=").with(:timeout, described_class::DEFAULT_TIMEOUT)
     end
 
     it "it sets the default timeout option when given" do
       timeout = 5
-      described_class.new("http://example.com", {timeout: timeout}).connection
+      described_class.new(api_key, braze_url, {timeout: timeout}).connection
 
       expect(options).to have_received(:"[]=").with(:timeout, timeout)
     end
 
     it "sets the headers" do
-      described_class.new("http://example.com").connection
+      described_class.new(api_key, braze_url).connection
 
 
       expect(headers).to have_received(:"[]=").with("Content-Type", "application/json")
       expect(headers).to have_received(:"[]=").with("Accept", "application/json")
       expect(headers).to have_received(:"[]=").with("User-Agent", "Braze Ruby gem v#{BrazeRuby::VERSION}")
+      expect(headers).to have_received(:"[]=").with("Authorization", "Bearer braze-api-key")
     end
 
     it "it sets the default adapter" do
-      described_class.new("http://example.com").connection
+      described_class.new(api_key, braze_url).connection
 
       expect(conn).to have_received(:adapter).with(:default_adapter)
     end

--- a/spec/braze_ruby/rest/delete_users_spec.rb
+++ b/spec/braze_ruby/rest/delete_users_spec.rb
@@ -9,14 +9,14 @@ describe BrazeRuby::REST::DeleteUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url, {}}
+  subject { described_class.new :api_key, :rest_url, {}}
 
   before { subject.http = http }
 
   it 'makes an http call to the delete user endpoint' do
     expect(http).to receive(:post).with '/users/delete',
-        payload.merge({ api_key: :api_key })
+        payload
 
-    subject.perform(api_key, payload)
+    subject.perform(payload)
   end
 end

--- a/spec/braze_ruby/rest/email_status_spec.rb
+++ b/spec/braze_ruby/rest/email_status_spec.rb
@@ -11,7 +11,6 @@ describe BrazeRuby::REST::EmailStatus do
 
   it 'makes an http call to the email status endpoint' do
     expect(http).to receive(:post).with '/email/status', {
-      api_key: :api_key,
       email: :email,
       subscription_state: :status
     }

--- a/spec/braze_ruby/rest/export_users_spec.rb
+++ b/spec/braze_ruby/rest/export_users_spec.rb
@@ -8,14 +8,14 @@ describe BrazeRuby::REST::ExportUsers do
   let(:payload) {{ external_ids: external_ids }}
   let(:external_ids) { [1] }
 
-  subject { described_class.new :rest_url, {} }
+  subject { described_class.new :api_key, :rest_url, {} }
 
   before { subject.http = http }
 
   it 'makes an http call to the track user endpoint' do
     expect(http).to receive(:post).with '/users/export/ids',
-        payload.merge({ api_key: :api_key })
+        payload
 
-    subject.perform(:api_key, payload)
+    subject.perform(**payload)
   end
 end

--- a/spec/braze_ruby/rest/identify_users_spec.rb
+++ b/spec/braze_ruby/rest/identify_users_spec.rb
@@ -10,14 +10,14 @@ describe BrazeRuby::REST::IdentifyUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url, {}}
+  subject { described_class.new :api_key, :rest_url, {}}
 
   before { subject.http = http }
 
   it 'makes an http call to the identify users endpoint' do
     expect(http).to receive(:post).with '/users/identify',
-        payload.merge({ api_key: :api_key })
+        payload
 
-    subject.perform(api_key, payload)
+    subject.perform(**payload)
   end
 end

--- a/spec/braze_ruby/rest/schedule_messages_spec.rb
+++ b/spec/braze_ruby/rest/schedule_messages_spec.rb
@@ -26,7 +26,6 @@ describe BrazeRuby::REST::ScheduleMessages do
 
   def expect_schedule_messages_http_call
     expect(http).to receive(:post).with '/messages/schedule/create', {
-      api_key: api_key,
       external_user_ids: :external_user_ids,
       schedule: {
         time: :time,

--- a/spec/braze_ruby/rest/send_messages_spec.rb
+++ b/spec/braze_ruby/rest/send_messages_spec.rb
@@ -29,7 +29,6 @@ describe BrazeRuby::REST::SendMessages do
 
   def expect_send_messages_http_call
     expect(http).to receive(:post).with '/messages/send', {
-      api_key: :api_key,
       messages: [],
       external_user_ids: [],
     }

--- a/spec/braze_ruby/rest/track_users_spec.rb
+++ b/spec/braze_ruby/rest/track_users_spec.rb
@@ -13,14 +13,14 @@ describe BrazeRuby::REST::TrackUsers do
 
   let(:api_key) { :api_key }
 
-  subject { described_class.new :rest_url, {}}
+  subject { described_class.new :api_key, :rest_url, {}}
 
   before { subject.http = http }
 
   it 'makes an http call to the track user endpoint' do
     expect(http).to receive(:post).with '/users/track',
-        payload.merge({ api_key: :api_key })
+        payload
 
-    subject.perform(api_key, payload)
+    subject.perform(**payload)
   end
 end

--- a/spec/fixtures/responses/campaigns/trigger_send/sends_an_email.yml
+++ b/spec/fixtures/responses/campaigns/trigger_send/sends_an_email.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/campaigns/trigger/send"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","campaign_id":"69e9b681-779c-4b4c-b6b8-cd74b17d21d2","recipients":[{"external_user_id":132404,"trigger_properties":{"first_name":"John"}}]}'
+      string: '{"campaign_id":"d8b73da7-0b7c-fc72-1d80-e59c7f20f0d3","recipients":[{"external_user_id":12345,"trigger_properties":{"first_name":"John"}}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,12 +22,16 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"838a7c62adda8d131d694ae13ba2c5b7"
+      - W/"b02a5788c87daf846d9cf451bf7f4e6d"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -36,34 +42,30 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '249998'
       X-Ratelimit-Reset:
-      - '1567425600'
+      - '1592427600'
       X-Request-Id:
-      - e6f14e03-5226-45f3-9a9f-901a0139b071
+      - ab80a33e-db36-4fe9-af89-6ce274df5edc
       X-Runtime:
-      - '0.019114'
-      Content-Length:
-      - '46'
+      - '0.016803'
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 02 Sep 2019 11:41:42 GMT
+      - Wed, 17 Jun 2020 20:04:46 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4029-HHN
+      - cache-hhn4039-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1567424502.370259,VS0,VE27
+      - S1592424287.720589,VS0,VE19
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"success"}'
+      string: '{"dispatch_id":"14497aa4b013bf150881547fb3076fd6","message":"success"}'
     http_version: 
-  recorded_at: Mon, 02 Sep 2019 11:41:42 GMT
+  recorded_at: Wed, 17 Jun 2020 20:04:46 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/canvas/details/returns_error_when_no_canvas.yml
+++ b/spec/fixtures/responses/canvas/details/returns_error_when_no_canvas.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/canvas/details?api_key=<BRAZE_REST_API_KEY>&canvas_id=non-existing"
+    uri: "<BRAZE_REST_URL>/canvas/details?canvas_id=non-existing"
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 400
       message: Bad Request
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '90'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -31,37 +37,33 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249999'
+      - '249996'
       X-Ratelimit-Reset:
-      - '1569931200'
+      - '1592427600'
       X-Request-Id:
-      - ef7a2c66-9020-4973-a76c-87ce14f2f266
+      - c034f03f-7a14-441a-8804-5ab472b339e5
       X-Runtime:
-      - '0.016301'
+      - '0.036143'
       Accept-Ranges:
       - bytes
       - bytes
-      Content-Length:
-      - '90'
       Date:
-      - Tue, 01 Oct 2019 11:36:37 GMT
+      - Wed, 17 Jun 2020 20:10:13 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4066-HHN
+      - cache-hhn4053-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1569929798.919907,VS0,VE19
+      - S1592424613.170617,VS0,VE40
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"canvas_id must be a string of the Canvas api identifier"}'
     http_version: 
-  recorded_at: Tue, 01 Oct 2019 11:36:37 GMT
+  recorded_at: Wed, 17 Jun 2020 20:10:13 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/canvas/trigger_send/sends_a_canvas.yml
+++ b/spec/fixtures/responses/canvas/trigger_send/sends_a_canvas.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/canvas/trigger/send"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","canvas_id":"dc23ade4-e970-0c52-81bc-b369f64f533d","recipients":[{"external_user_id":132404,"canvas_entry_properties":{"first_name":"John"}}]}'
+      string: '{"canvas_id":"70a7fb99-cbcb-451a-8224-5f8b8c63e03f","recipients":[{"external_user_id":12345,"canvas_entry_properties":{"first_name":"John"}}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.1
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,12 +22,16 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"fe0b7fad99d691854e76da70f1fcfff9"
+      - W/"8095773a816c64baf32bfaed3bbc98c5"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -34,36 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249998'
+      - '249997'
       X-Ratelimit-Reset:
-      - '1569409200'
+      - '1592427600'
       X-Request-Id:
-      - 768c83db-2694-4267-b21c-d070cb4a1828
+      - f1378a46-afca-42ec-bfdd-3c624a75bc6b
       X-Runtime:
-      - '0.023062'
-      Content-Length:
-      - '94'
+      - '0.035689'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 25 Sep 2019 10:36:45 GMT
+      - Wed, 17 Jun 2020 20:08:51 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-fra19174-FRA
+      - cache-hhn4034-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1569407805.340414,VS0,VE71
+      - S1592424531.067560,VS0,VE38
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"dispatch_id":"0bda43218769391588ee304c36fafb03","message":"success"}'
+      string: '{"dispatch_id":"c249b5eaad19a96b85ce3afc83017e81","message":"success"}'
     http_version: 
-  recorded_at: Wed, 25 Sep 2019 10:36:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:08:51 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/delete_users/unauthorized/responds_with_unauthorized.yml
+++ b/spec/fixtures/responses/delete_users/unauthorized/responds_with_unauthorized.yml
@@ -5,21 +5,27 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/delete"
     body:
       encoding: UTF-8
-      string: '{"api_key":"non-existent","external_ids":[400,401,402]}'
+      string: '{"external_ids":[400,401,402]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer non-existent
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 401
       message: Unauthorized
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -35,32 +41,28 @@ http_interactions:
       X-Ratelimit-Reset:
       - ''
       X-Request-Id:
-      - bd4c1e19-8065-4db0-b5e5-aaafcb40ef9d
+      - '0335584f-5add-47dd-9476-fecfe3ee350d'
       X-Runtime:
-      - '0.011342'
-      Content-Length:
-      - '85'
+      - '0.001182'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 18 May 2018 18:54:32 GMT
+      - Wed, 17 Jun 2020 20:59:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17824-PDK
+      - cache-hhn4081-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1526669672.332248,VS0,VE196
+      - S1592427573.501246,VS0,VE4
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"Invalid App Group API Identifier: non-existent"}'
+      string: '{"message":"Invalid API key: non-existent"}'
     http_version: 
-  recorded_at: Fri, 18 May 2018 18:54:14 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:59:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/delete_users/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/delete_users/with_success/responds_with_created.yml
@@ -5,65 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/delete"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_ids":[400,401,402]}'
+      string: '{"external_ids":[400,401,402]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"383e14c9bc8f36ee9f92221ad86557aa"
+      - W/"9a22d0f53e9efcbef8e52c6a21060bc1"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49988'
+      - '249937'
       X-Ratelimit-Reset:
-      - '1526670000'
+      - '1592427600'
       X-Request-Id:
-      - 3c706f21-aef5-4527-ab35-ded3437dbb58
+      - dd8e1db7-bb0d-4e71-a14a-c4c5c9322f49
       X-Runtime:
-      - '0.019468'
-      Content-Length:
-      - '89'
+      - '0.005861'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 18 May 2018 18:54:31 GMT
+      - Wed, 17 Jun 2020 20:59:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-atl6224-ATL
+      - cache-hhn4035-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1526669672.735390,VS0,VE223
+      - S1592427572.293833,VS0,VE9
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"invalid_user_ids":[400,401,402],"deleted":3,"message":"success"}'
-    http_version:
-  recorded_at: Fri, 18 May 2018 18:54:13 GMT
-recorded_with: VCR 4.0.0
+      string: '{"deleted":3,"message":"success"}'
+    http_version: 
+  recorded_at: Wed, 17 Jun 2020 20:59:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/delete_users/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/delete_users/with_success/responds_with_success_message.yml
@@ -5,65 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/delete"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_ids":[400,401,402]}'
+      string: '{"external_ids":[400,401,402]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"05c5a9339e57ae2f67e0aeb4404dbe22"
+      - W/"9a22d0f53e9efcbef8e52c6a21060bc1"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49987'
+      - '249936'
       X-Ratelimit-Reset:
-      - '1526670000'
+      - '1592427600'
       X-Request-Id:
-      - 51543cb0-651c-49ea-aaba-ca8350e763bd
+      - '096a3b98-e784-4eb4-ba32-dd18749c3ceb'
       X-Runtime:
-      - '0.011310'
-      Content-Length:
-      - '89'
+      - '0.006707'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 18 May 2018 18:54:32 GMT
+      - Wed, 17 Jun 2020 20:59:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-atl6222-ATL
+      - cache-hhn4059-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1526669672.051288,VS0,VE215
+      - S1592427572.403094,VS0,VE9
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"invalid_user_ids":[400,401,402],"deleted":0,"message":"success"}'
-    http_version:
-  recorded_at: Fri, 18 May 2018 18:54:14 GMT
-recorded_with: VCR 4.0.0
+      string: '{"deleted":3,"message":"success"}'
+    http_version: 
+  recorded_at: Wed, 17 Jun 2020 20:59:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/existing_email/responds_with_created.yml
+++ b/spec/fixtures/responses/email_status/existing_email/responds_with_created.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/email/status"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"john@example.com","subscription_state":"unsubscribed"}'
+      string: '{"email":"john@example.com","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249992'
+      - '249999'
       X-Ratelimit-Reset:
-      - '1592424000'
+      - '1592478000'
       X-Request-Id:
-      - 1ee7ae21-cf92-47e4-bf40-64f5ad798a34
+      - 959f568d-946e-44c9-9974-67a798be5df1
       X-Runtime:
-      - '0.006066'
+      - '0.042493'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 19:25:40 GMT
+      - Thu, 18 Jun 2020 10:02:13 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4042-HHN
+      - cache-hhn4031-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592421940.179522,VS0,VE9
+      - S1592474534.753827,VS0,VE46
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+  recorded_at: Thu, 18 Jun 2020 10:02:13 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/existing_email/responds_with_created.yml
+++ b/spec/fixtures/responses/email_status/existing_email/responds_with_created.yml
@@ -7,19 +7,25 @@ http_interactions:
       encoding: UTF-8
       string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"john@example.com","subscription_state":"unsubscribed"}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -32,38 +38,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49999'
+      - '249992'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592424000'
       X-Request-Id:
-      - 24433bbb-89d6-4bd3-918f-46e7865d383e
+      - 1ee7ae21-cf92-47e4-bf40-64f5ad798a34
       X-Runtime:
-      - '0.034502'
-      Content-Length:
-      - '46'
+      - '0.006066'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:19 GMT
+      - Wed, 17 Jun 2020 19:25:40 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17830-PDK
+      - cache-hhn4042-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999299.770713,VS0,VE230
+      - S1592421940.179522,VS0,VE9
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:19 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/existing_email/responds_with_success_message.yml
+++ b/spec/fixtures/responses/email_status/existing_email/responds_with_success_message.yml
@@ -7,19 +7,25 @@ http_interactions:
       encoding: UTF-8
       string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"john@example.com","subscription_state":"unsubscribed"}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -32,38 +38,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49998'
+      - '249991'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592424000'
       X-Request-Id:
-      - 57d0c42f-8187-434e-82ad-bc57b93af0d7
+      - c503142a-a790-4669-9503-41bfb2a3c0f3
       X-Runtime:
-      - '0.031383'
-      Content-Length:
-      - '46'
+      - '0.007165'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:19 GMT
+      - Wed, 17 Jun 2020 19:25:40 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17831-PDK
+      - cache-hhn4061-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999299.122858,VS0,VE189
+      - S1592421940.294650,VS0,VE10
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:19 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/existing_email/responds_with_success_message.yml
+++ b/spec/fixtures/responses/email_status/existing_email/responds_with_success_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/email/status"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"john@example.com","subscription_state":"unsubscribed"}'
+      string: '{"email":"john@example.com","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249991'
+      - '249998'
       X-Ratelimit-Reset:
-      - '1592424000'
+      - '1592478000'
       X-Request-Id:
-      - c503142a-a790-4669-9503-41bfb2a3c0f3
+      - 0a969f62-62e0-4bf7-916b-c96ca026a82d
       X-Runtime:
-      - '0.007165'
+      - '0.006404'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 19:25:40 GMT
+      - Thu, 18 Jun 2020 10:02:14 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4061-HHN
+      - cache-hhn4063-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592421940.294650,VS0,VE10
+      - S1592474534.098150,VS0,VE9
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+  recorded_at: Thu, 18 Jun 2020 10:02:14 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/unknown_email/responds_with_bad_request.yml
+++ b/spec/fixtures/responses/email_status/unknown_email/responds_with_bad_request.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/email/status"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"notthere@example.com","subscription_state":"unsubscribed"}'
+      string: '{"email":"notthere@example.com","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249990'
+      - '249997'
       X-Ratelimit-Reset:
-      - '1592424000'
+      - '1592478000'
       X-Request-Id:
-      - 4e43d022-880d-4b26-b147-f17322b893d7
+      - ea52a572-1445-4d30-89f0-87595863fc6a
       X-Runtime:
-      - '0.006838'
+      - '0.006073'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 19:25:40 GMT
+      - Thu, 18 Jun 2020 10:02:14 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4073-HHN
+      - cache-hhn4061-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592421940.408208,VS0,VE10
+      - S1592474534.256187,VS0,VE9
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+  recorded_at: Thu, 18 Jun 2020 10:02:14 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/unknown_email/responds_with_bad_request.yml
+++ b/spec/fixtures/responses/email_status/unknown_email/responds_with_bad_request.yml
@@ -7,19 +7,25 @@ http_interactions:
       encoding: UTF-8
       string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"notthere@example.com","subscription_state":"unsubscribed"}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -32,38 +38,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49997'
+      - '249990'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592424000'
       X-Request-Id:
-      - 5d962401-96ee-484d-b6a1-84accd7877d7
+      - 4e43d022-880d-4b26-b147-f17322b893d7
       X-Runtime:
-      - '0.032026'
-      Content-Length:
-      - '46'
+      - '0.006838'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:19 GMT
+      - Wed, 17 Jun 2020 19:25:40 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17834-PDK
+      - cache-hhn4073-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999299.420584,VS0,VE200
+      - S1592421940.408208,VS0,VE10
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:19 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/unknown_email/responds_with_success_message.yml
+++ b/spec/fixtures/responses/email_status/unknown_email/responds_with_success_message.yml
@@ -7,19 +7,25 @@ http_interactions:
       encoding: UTF-8
       string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"notthere@example.com","subscription_state":"unsubscribed"}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -32,38 +38,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49996'
+      - '249989'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592424000'
       X-Request-Id:
-      - 3050a957-b5b3-4f16-bdd1-c42ac5718d67
+      - cb7461f4-ce7b-42f8-84b5-e02a6b6ec10e
       X-Runtime:
-      - '0.013591'
-      Content-Length:
-      - '46'
+      - '0.007939'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:19 GMT
+      - Wed, 17 Jun 2020 19:25:40 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17843-PDK
+      - cache-hhn4077-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999300.711704,VS0,VE182
+      - S1592421941.513159,VS0,VE11
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_status/unknown_email/responds_with_success_message.yml
+++ b/spec/fixtures/responses/email_status/unknown_email/responds_with_success_message.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/email/status"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","email":"notthere@example.com","subscription_state":"unsubscribed"}'
+      string: '{"email":"notthere@example.com","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249989'
+      - '249996'
       X-Ratelimit-Reset:
-      - '1592424000'
+      - '1592478000'
       X-Request-Id:
-      - cb7461f4-ce7b-42f8-84b5-e02a6b6ec10e
+      - 7d2e393e-02fa-41b0-9a6f-fb8f51a08afb
       X-Runtime:
-      - '0.007939'
+      - '0.008835'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 19:25:40 GMT
+      - Thu, 18 Jun 2020 10:02:14 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4077-HHN
+      - cache-hhn4049-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592421941.513159,VS0,VE11
+      - S1592474535.665937,VS0,VE11
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 19:25:40 GMT
+  recorded_at: Thu, 18 Jun 2020 10:02:14 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_sync/hard_bounces/responds_with_empty_array_when_no_hard_bounces.yml
+++ b/spec/fixtures/responses/email_sync/hard_bounces/responds_with_empty_array_when_no_hard_bounces.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/email/hard_bounces?api_key=<BRAZE_REST_API_KEY>&end_date=2019-02-25&start_date=2019-02-20"
+    uri: "<BRAZE_REST_URL>/email/hard_bounces?end_date=2019-02-25&start_date=2019-02-20"
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.1.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,40 +40,36 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249997'
+      - '249926'
       X-Ratelimit-Reset:
-      - '1554469200'
+      - '1592424000'
       X-Request-Id:
-      - c558e8fa-6297-4781-ae01-e3578c6cf5cc
+      - 9e895539-7966-4416-8341-9a8d2342185c
       X-Runtime:
-      - '0.036732'
+      - '0.030985'
       Accept-Ranges:
       - bytes
       - bytes
       Age:
       - '0'
       - '0'
-      Transfer-Encoding:
-      - chunked
       Date:
-      - Fri, 05 Apr 2019 12:42:30 GMT
+      - Wed, 17 Jun 2020 19:46:17 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-ams21022-AMS
+      - cache-hhn4077-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1554468150.427045,VS0,VE47
+      - S1592423178.514432,VS0,VE84
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"emails":[],"message":"success"}'
     http_version: 
-  recorded_at: Fri, 05 Apr 2019 12:42:30 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:46:17 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_sync/unsubscribes/responds_with_empty_array_when_no_unsubscribes.yml
+++ b/spec/fixtures/responses/email_sync/unsubscribes/responds_with_empty_array_when_no_unsubscribes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/email/unsubscribes?api_key=<BRAZE_REST_API_KEY>&end_date=2019-02-25&start_date=2019-02-20"
+    uri: "<BRAZE_REST_URL>/email/unsubscribes?end_date=2019-02-25&start_date=2019-02-20"
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.1.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '58'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,40 +40,36 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249995'
+      - '249927'
       X-Ratelimit-Reset:
-      - '1554469200'
+      - '1592424000'
       X-Request-Id:
-      - 789be9aa-f170-4720-8e99-69225027766a
+      - 8e05ec17-15c3-43a1-a79b-ce8a60c2c89e
       X-Runtime:
-      - '0.090793'
+      - '0.021148'
       Accept-Ranges:
       - bytes
       - bytes
       Age:
       - '0'
       - '0'
-      Transfer-Encoding:
-      - chunked
       Date:
-      - Fri, 05 Apr 2019 12:44:12 GMT
+      - Wed, 17 Jun 2020 19:45:35 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-ams21050-AMS
+      - cache-hhn4021-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1554468252.044685,VS0,VE101
+      - S1592423135.200434,VS0,VE30
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"emails":[],"message":"success"}'
     http_version: 
-  recorded_at: Fri, 05 Apr 2019 12:44:12 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 19:45:35 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/email_sync/unsubscribes/responds_with_unsubscribed_emails.yml
+++ b/spec/fixtures/responses/email_sync/unsubscribes/responds_with_unsubscribed_emails.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/email/unsubscribes?api_key=<BRAZE_REST_API_KEY>&end_date=2019-03-25&start_date=2019-03-20"
+    uri: "<BRAZE_REST_URL>/email/unsubscribes?end_date=2020-06-18&start_date=2020-06-17"
     body:
       encoding: US-ASCII
       string: ''
@@ -12,7 +12,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.1.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,12 +22,16 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"5eb0e9bcc8119b72a7bccb6a7195558f"
+      - W/"e65c6449e615b3f001070538af4b6fd9"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -34,41 +40,36 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249996'
+      - '249928'
       X-Ratelimit-Reset:
-      - '1554469200'
+      - '1592424000'
       X-Request-Id:
-      - fa9392d1-098a-406c-9957-9f8f504b3263
+      - 71487406-0d6c-4384-906e-b5cddf19d5b4
       X-Runtime:
-      - '0.118162'
+      - '0.011941'
       Accept-Ranges:
       - bytes
       - bytes
       Age:
       - '0'
       - '0'
-      Transfer-Encoding:
-      - chunked
       Date:
-      - Fri, 05 Apr 2019 12:44:11 GMT
+      - Wed, 17 Jun 2020 19:42:36 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-ams21026-AMS
+      - cache-hhn4028-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1554468252.696233,VS0,VE128
+      - S1592422957.581337,VS0,VE15
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"emails":[{"email":"wojtek@test.com","unsubscribed_at":"2019-03-21
-        16:31:31 +0000"}],"message":"success"}'
-    http_version:
-  recorded_at: Fri, 05 Apr 2019 12:44:11 GMT
-recorded_with: VCR 4.0.0
+      string: '{"emails":[{"email":"example@123.com","unsubscribed_at":"2020-06-17 19:27:44 +0000"}], "message":"success"}'
+    http_version: 
+  recorded_at: Wed, 17 Jun 2020 19:42:36 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/export_users/by_ids/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/export_users/by_ids/with_success/responds_with_created.yml
@@ -5,65 +5,68 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/export/ids"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_ids":[1]}'
+      string: '{"external_ids":[12345]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '448'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"a8eccb6359ba1adb300e19da464d87e6"
+      - W/"7df8cd8f88a14f379a69f3838271d7fc"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49995'
+      - '249995'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - f720263b-e324-49ea-a74b-b6855cf41336
+      - 4d9fd8a1-a8bb-4e20-99b1-063365c51808
       X-Runtime:
-      - '0.083452'
-      Content-Length:
-      - '319'
+      - '0.342278'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:20 GMT
+      - Wed, 17 Jun 2020 20:14:30 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17841-PDK
+      - cache-hhn4030-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999300.120226,VS0,VE267
+      - S1592424870.344107,VS0,VE345
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"users":[{"created_at":"2018-04-17T17:28:56.807Z","external_id":"1","user_aliases":[],"appboy_id":"5ad62ed85941bafd80298dfc","braze_id":"5ad62ed85941bafd80298dfc","random_bucket":2118,"home_city":null,"total_revenue":19.03,"push_subscribe":"subscribed","email_subscribe":"subscribed","custom_attributes":{"foo":"bar"},"apps":[],"custom_events":[{"name":"baz","first":"2015-02-15T05:00:00.000Z","last":"2019-02-15T05:00:00.000Z","count":24}],"purchases":[{"name":"1","first":"2015-02-15T05:00:00.000Z","last":"2019-02-15T05:00:00.000Z","count":24}]}],"invalid_user_ids":[1],"message":"success"}'
+      string: '{"users":[{"created_at":"2020-06-17T20:01:33.385Z","external_id":"12345","user_aliases":[],"appboy_id":"5eea769d45bb2e1467418f92","braze_id":"5eea769d45bb2e1467418f92","first_name":"John","last_name":"Doe","random_bucket":5445,"email":"example@test.com","custom_attributes":{"string_attribute":"sherman","boolean_attribute_1":true,"integer_attribute":25,"array_attribute":["banana","apple"]},"total_revenue":0.0,"push_subscribe":"subscribed","email_subscribe":"subscribed","campaigns_received":[{"name":"campaign-test","api_campaign_id":"d8b73da7-0b7c-fc72-1d80-e59c7f20f0d3","last_received":"2020-06-17T20:04:49.193Z","in_control":false,"variation_name":"Variant
+        1","variation_api_id":"f2123be2-74ac-4cff-b010-d0b6217595a1"}]}],"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:14:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/export_users/by_segment/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/export_users/by_segment/with_success/responds_with_created.yml
@@ -5,65 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/export/segment"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","segment_id":"a8fde797-4c44-4406-8e6c-5850d323f169","callback_endpoint":"https://example.com"}'
+      string: '{"segment_id":"3aca937b-9bbc-4e42-9370-05e411967b2b","callback_endpoint":"https://example.com"}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"3ea7dd8571456c18ee0f64e21588cd18"
+      - W/"2e35da6e340b6bc894c81eb5d32fe5bd"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49994'
+      - '249994'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - 383a399b-8622-432b-8e8c-3466bb2918aa
+      - 15c5b986-e83c-4fc5-bc7c-8245f2c10185
       X-Runtime:
-      - '0.019441'
-      Content-Length:
-      - '193'
+      - '0.065960'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:20 GMT
+      - Wed, 17 Jun 2020 20:14:30 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17823-PDK
+      - cache-hhn4075-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999301.520355,VS0,VE192
+      - S1592424871.804901,VS0,VE69
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"url":"https://appboy-03-data-export.s3.amazonaws.com/6GyY08ekLymivv4VS0uQFeWV1yP1OV99jgrGSJ4MmYg.zip","object_prefix":"9665a629-c9b2-499b-a2d8-f1f6fc19cf64-1523999300","message":"success"}'
+      string: '{"object_prefix":"e739ed46-9cd7-4142-b70f-843b89c5ac80-1592424870","url":"https://appboy-eu-data-export.s3.amazonaws.com/Iw_2CAuI2mvAemo2jRTbG6IBUkzpJNBbYSMwPHO082o.zip","message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:14:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/identify_users/unauthorized/responds_with_unauthorized.yml
+++ b/spec/fixtures/responses/identify_users/unauthorized/responds_with_unauthorized.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/identify"
     body:
       encoding: UTF-8
-      string: '{"api_key":"non-existent","aliases_to_identify":[{"external_id":400,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
+      string: '{"aliases_to_identify":[{"external_id":12345,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.3.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer non-existent
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -39,28 +41,28 @@ http_interactions:
       X-Ratelimit-Reset:
       - ''
       X-Request-Id:
-      - 8bd7f08e-2a28-4cac-af20-26dbf479eeb2
+      - 004f6dde-0f46-4aeb-b709-fc6481536807
       X-Runtime:
-      - '0.006500'
+      - '0.001028'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 19 Dec 2019 20:55:45 GMT
+      - Wed, 17 Jun 2020 20:30:16 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-msp20825-MSP
+      - cache-hhn4046-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1576788945.296140,VS0,VE43
+      - S1592425816.333073,VS0,VE4
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid API key: non-existent"}'
     http_version: 
-  recorded_at: Thu, 19 Dec 2019 20:55:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:30:16 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/identify_users/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/identify_users/with_success/responds_with_created.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/identify"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","aliases_to_identify":[{"external_id":400,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
+      string: '{"aliases_to_identify":[{"external_id":12345,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.3.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -38,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249975'
+      - '249982'
       X-Ratelimit-Reset:
-      - '1576789200'
+      - '1592427600'
       X-Request-Id:
-      - 9348cf6f-365f-43fe-b460-f956c932097d
+      - d0f2ec14-ad20-4ec1-8c98-e082ba1a29a7
       X-Runtime:
-      - '0.005338'
+      - '0.007261'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 19 Dec 2019 20:55:44 GMT
+      - Wed, 17 Jun 2020 20:30:11 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-msp20820-MSP
+      - cache-hhn4027-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1576788945.699710,VS0,VE187
+      - S1592425811.496339,VS0,VE10
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"aliases_processed":1,"message":"success"}'
     http_version: 
-  recorded_at: Thu, 19 Dec 2019 20:55:44 GMT
+  recorded_at: Wed, 17 Jun 2020 20:30:11 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/identify_users/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/identify_users/with_success/responds_with_success_message.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/identify"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","aliases_to_identify":[{"external_id":400,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
+      string: '{"aliases_to_identify":[{"external_id":12345,"user_alias":{"alias_name":"abc","alias_label":"foo"}}]}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.3.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -38,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249974'
+      - '249981'
       X-Ratelimit-Reset:
-      - '1576789200'
+      - '1592427600'
       X-Request-Id:
-      - 6df46e00-4a8a-4b57-8acf-849cbc53c569
+      - 3e3620bf-17ee-4cb6-9bcf-252339f664e2
       X-Runtime:
-      - '0.005888'
+      - '0.005803'
       Accept-Ranges:
       - bytes
       Date:
-      - Thu, 19 Dec 2019 20:55:45 GMT
+      - Wed, 17 Jun 2020 20:30:16 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-msp20823-MSP
+      - cache-hhn4021-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1576788945.958885,VS0,VE226
+      - S1592425816.221760,VS0,VE9
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"aliases_processed":1,"message":"success"}'
     http_version: 
-  recorded_at: Thu, 19 Dec 2019 20:55:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:30:16 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/list_segments/with_success/responds_with_a_list_of_segments.yml
+++ b/spec/fixtures/responses/list_segments/with_success/responds_with_a_list_of_segments.yml
@@ -2,80 +2,80 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/segments/list?api_key=<BRAZE_REST_API_KEY>"
+    uri: "<BRAZE_REST_URL>/segments/list"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
       User-Agent:
-      - Faraday v0.14.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"f82a7689f0f1df180510d033adeece51"
+      - W/"de13291b9300bcefd33634ff4545a157"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49992'
+      - '249938'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - a399cc89-0854-471e-aba3-71f3a79a4f47
+      - 8768b6f0-071c-44f0-b09e-eb14bdebfa54
       X-Runtime:
-      - '0.017686'
-      Content-Length:
-      - '603'
+      - '0.011164'
       Accept-Ranges:
       - bytes
-      Date:
-      - Tue, 17 Apr 2018 21:08:20 GMT
-      Via:
-      - 1.1 varnish
+      - bytes
       Age:
       - '0'
-      Connection:
-      - keep-alive
+      - '0'
+      Date:
+      - Wed, 17 Jun 2020 20:57:03 GMT
+      Via:
+      - 1.1 varnish
       X-Served-By:
-      - cache-pdk17835-PDK
+      - cache-hhn4066-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999301.931262,VS0,VE59
+      - S1592427424.534728,VS0,VE14
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"segments":[{"id":"e094130b-8b90-4b01-a004-f2b25281564f","name":"Lapsed
-        Users - 7 days","analytics_tracking_enabled":true,"tags":[]},{"id":"f77809b7-dda4-45ee-bcf4-46de5c58a0a2","name":"Lapsed
-        Users - 30 days","analytics_tracking_enabled":true,"tags":[]},{"id":"61227661-f46e-4ab6-bbc9-e4d5f65f8dbc","name":"User
-        Onboarding - First Week","analytics_tracking_enabled":true,"tags":[]},{"id":"0ccb0f97-b09c-4d0f-bc33-8c695c6eedf2","name":"User
-        Onboarding - Second Week","analytics_tracking_enabled":true,"tags":[]},{"id":"f522dea9-d27c-48b9-8e98-c03b3346e4b4","name":"Engaged
-        Recent Users","analytics_tracking_enabled":true,"tags":[]},{"id":"658307d8-3b8a-45fa-98ad-97fb75ee6eff","name":"All
-        Users (Takl Staging - iOS)","analytics_tracking_enabled":true,"tags":[]},{"id":"d04aa317-a6f4-459d-b7c0-2b1cab68cb88","name":"All
-        Users (Takl Staging - Android)","analytics_tracking_enabled":true,"tags":[]},{"id":"e2ff24e9-0d5d-4b50-8832-a4201b1d59a3","name":"All
-        Users (Takl Staging Debug - Android)","analytics_tracking_enabled":true,"tags":[]},{"id":"3de3ddbf-a327-408b-aab4-6bd390a6409e","name":"All
-        Users (Takl Staging - Web)","analytics_tracking_enabled":true,"tags":[]},{"id":"b109727d-4773-4cdf-b6c7-43385aa9ccb2","name":"Everybody","analytics_tracking_enabled":false,"tags":[]},{"id":"ef0a9a5e-c0be-41a0-9260-2718dfbe28d4","name":"Custom
-        Event Segment","analytics_tracking_enabled":false,"tags":[]},{"id":"7a337f50-4e79-46f6-b8b2-2459027e9aca","name":"Morgans
-        Segment","analytics_tracking_enabled":false,"tags":[]},{"id":"a8fde797-4c44-4406-8e6c-5850d323f169","name":"Justin''s
-        Segment","analytics_tracking_enabled":false,"tags":[]}],"message":"success"}'
+      string: '{"segments":[{"id":"6d68ea15-26c4-4109-835a-65b81773a5e2","name":"Lapsed
+        Users - 7 days","analytics_tracking_enabled":true,"tags":[]},{"id":"0eaf8f6a-230f-48f2-9c01-45302b642a35","name":"Lapsed
+        Users - 30 days","analytics_tracking_enabled":true,"tags":[]},{"id":"b644b893-276d-4817-b5cd-5f65906f072b","name":"User
+        Onboarding - First Week","analytics_tracking_enabled":true,"tags":[]},{"id":"2f59d81c-82b3-40e5-9050-b6400a1fc9c8","name":"User
+        Onboarding - Second Week","analytics_tracking_enabled":true,"tags":[]},{"id":"de83cb66-cc1f-457d-8905-45446b6e841b","name":"Engaged
+        Recent Users","analytics_tracking_enabled":true,"tags":[]},{"id":"3aca937b-9bbc-4e42-9370-05e411967b2b","name":"All
+        Users (Freeletics Development - iOS)","analytics_tracking_enabled":true,"tags":[]}],"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:57:03 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/list_segments/with_success/responds_with_success.yml
+++ b/spec/fixtures/responses/list_segments/with_success/responds_with_success.yml
@@ -2,80 +2,80 @@
 http_interactions:
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/segments/list?api_key=<BRAZE_REST_API_KEY>"
+    uri: "<BRAZE_REST_URL>/segments/list"
     body:
       encoding: US-ASCII
       string: ''
     headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
       User-Agent:
-      - Faraday v0.14.0
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '373'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"f82a7689f0f1df180510d033adeece51"
+      - W/"de13291b9300bcefd33634ff4545a157"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49993'
+      - '249939'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - 79e46360-b955-47cf-87b2-8e3e1a6f5ced
+      - 412888e3-1e15-4c24-bece-a87ed07fa3a4
       X-Runtime:
-      - '0.020006'
-      Content-Length:
-      - '603'
+      - '0.030416'
       Accept-Ranges:
       - bytes
-      Date:
-      - Tue, 17 Apr 2018 21:08:20 GMT
-      Via:
-      - 1.1 varnish
+      - bytes
       Age:
       - '0'
-      Connection:
-      - keep-alive
+      - '0'
+      Date:
+      - Wed, 17 Jun 2020 20:57:03 GMT
+      Via:
+      - 1.1 varnish
       X-Served-By:
-      - cache-pdk17843-PDK
+      - cache-hhn4021-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999301.800558,VS0,VE61
+      - S1592427423.407930,VS0,VE34
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"segments":[{"id":"e094130b-8b90-4b01-a004-f2b25281564f","name":"Lapsed
-        Users - 7 days","analytics_tracking_enabled":true,"tags":[]},{"id":"f77809b7-dda4-45ee-bcf4-46de5c58a0a2","name":"Lapsed
-        Users - 30 days","analytics_tracking_enabled":true,"tags":[]},{"id":"61227661-f46e-4ab6-bbc9-e4d5f65f8dbc","name":"User
-        Onboarding - First Week","analytics_tracking_enabled":true,"tags":[]},{"id":"0ccb0f97-b09c-4d0f-bc33-8c695c6eedf2","name":"User
-        Onboarding - Second Week","analytics_tracking_enabled":true,"tags":[]},{"id":"f522dea9-d27c-48b9-8e98-c03b3346e4b4","name":"Engaged
-        Recent Users","analytics_tracking_enabled":true,"tags":[]},{"id":"658307d8-3b8a-45fa-98ad-97fb75ee6eff","name":"All
-        Users (Takl Staging - iOS)","analytics_tracking_enabled":true,"tags":[]},{"id":"d04aa317-a6f4-459d-b7c0-2b1cab68cb88","name":"All
-        Users (Takl Staging - Android)","analytics_tracking_enabled":true,"tags":[]},{"id":"e2ff24e9-0d5d-4b50-8832-a4201b1d59a3","name":"All
-        Users (Takl Staging Debug - Android)","analytics_tracking_enabled":true,"tags":[]},{"id":"3de3ddbf-a327-408b-aab4-6bd390a6409e","name":"All
-        Users (Takl Staging - Web)","analytics_tracking_enabled":true,"tags":[]},{"id":"b109727d-4773-4cdf-b6c7-43385aa9ccb2","name":"Everybody","analytics_tracking_enabled":false,"tags":[]},{"id":"ef0a9a5e-c0be-41a0-9260-2718dfbe28d4","name":"Custom
-        Event Segment","analytics_tracking_enabled":false,"tags":[]},{"id":"7a337f50-4e79-46f6-b8b2-2459027e9aca","name":"Morgans
-        Segment","analytics_tracking_enabled":false,"tags":[]},{"id":"a8fde797-4c44-4406-8e6c-5850d323f169","name":"Justin''s
-        Segment","analytics_tracking_enabled":false,"tags":[]}],"message":"success"}'
+      string: '{"segments":[{"id":"6d68ea15-26c4-4109-835a-65b81773a5e2","name":"Lapsed
+        Users - 7 days","analytics_tracking_enabled":true,"tags":[]},{"id":"0eaf8f6a-230f-48f2-9c01-45302b642a35","name":"Lapsed
+        Users - 30 days","analytics_tracking_enabled":true,"tags":[]},{"id":"b644b893-276d-4817-b5cd-5f65906f072b","name":"User
+        Onboarding - First Week","analytics_tracking_enabled":true,"tags":[]},{"id":"2f59d81c-82b3-40e5-9050-b6400a1fc9c8","name":"User
+        Onboarding - Second Week","analytics_tracking_enabled":true,"tags":[]},{"id":"de83cb66-cc1f-457d-8905-45446b6e841b","name":"Engaged
+        Recent Users","analytics_tracking_enabled":true,"tags":[]},{"id":"3aca937b-9bbc-4e42-9370-05e411967b2b","name":"All
+        Users (Freeletics Development - iOS)","analytics_tracking_enabled":true,"tags":[]}],"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:20 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:57:03 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/schedule_messages/unauthorized/responds_with_unauthorize.yml
+++ b/spec/fixtures/responses/schedule_messages/unauthorized/responds_with_unauthorize.yml
@@ -5,22 +5,27 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/schedule/create"
     body:
       encoding: UTF-8
-      string: '{"api_key":"non-existent","external_user_ids":[1],"schedule":{"time":"2019-02-15
-        00:00:00 -0500","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
+      string: '{"external_user_ids":[12345],"schedule":{"time":"2020-08-07T00:00:00+02:00","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer non-existent
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 401
       message: Unauthorized
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -36,32 +41,28 @@ http_interactions:
       X-Ratelimit-Reset:
       - ''
       X-Request-Id:
-      - 34c2cbbd-02bb-4104-9c06-47cb08bd061c
+      - 3cd85b44-7a41-4e11-9895-14831b3cdf37
       X-Runtime:
-      - '0.008932'
-      Content-Length:
-      - '85'
+      - '0.001125'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:21 GMT
+      - Wed, 17 Jun 2020 20:50:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17829-PDK
+      - cache-hhn4038-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999302.620925,VS0,VE191
+      - S1592427032.395590,VS0,VE4
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"Invalid App Group API Identifier: non-existent"}'
+      string: '{"message":"Invalid API key: non-existent"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:21 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:50:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/schedule_messages/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/schedule_messages/with_success/responds_with_created.yml
@@ -5,66 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/schedule/create"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_user_ids":[1],"schedule":{"time":"2019-02-15
-        00:00:00 -0500","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
+      string: '{"external_user_ids":[12345],"schedule":{"time":"2020-08-07T00:00:00+02:00","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"f9913a2616a9d19ab2dafed53b6ac0cd"
+      - W/"8c104b66ec08064a5fe69a3f901841a2"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49991'
+      - '249941'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - fd1ed05b-89a1-4419-8402-34599af22c88
+      - 941b3cc1-49e6-4f2f-b32e-cd9181852657
       X-Runtime:
-      - '0.029549'
-      Content-Length:
-      - '96'
+      - '0.011838'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:21 GMT
+      - Wed, 17 Jun 2020 20:50:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17849-PDK
+      - cache-hhn4054-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999301.065052,VS0,VE210
+      - S1592427032.164784,VS0,VE14
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"schedule_id":"db90f8dc-2ef3-420f-a4b0-c08605acc21f","message":"success"}'
+      string: '{"dispatch_id":"09d7ffeef18452ecd6f3279811f3cf47","schedule_id":"886a0a5a-75fb-4d2f-9f19-c6a1e0017fa8","message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:21 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:50:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/schedule_messages/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/schedule_messages/with_success/responds_with_success_message.yml
@@ -5,66 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/schedule/create"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_user_ids":[1],"schedule":{"time":"2019-02-15
-        00:00:00 -0500","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
+      string: '{"external_user_ids":[12345],"schedule":{"time":"2020-08-07T00:00:00+02:00","in_local_time":false},"messages":{"apple_push":{"alert":"hello"}}}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '128'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"28a09ecfebb2ce520ec4eb59271fe82b"
+      - W/"1bad0ea6fb5d290969fb1438dfdce7b7"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49990'
+      - '249940'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - c55b095e-a19a-45d9-bb3d-1203b0c85b69
+      - fd262aec-d04b-435c-8b1d-a5b6358cc612
       X-Runtime:
-      - '0.017538'
-      Content-Length:
-      - '98'
+      - '0.018567'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:21 GMT
+      - Wed, 17 Jun 2020 20:50:32 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17831-PDK
+      - cache-hhn4055-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999301.354059,VS0,VE199
+      - S1592427032.276304,VS0,VE25
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"schedule_id":"31d4c1d9-d784-4218-abee-c95e03a30f03","message":"success"}'
+      string: '{"dispatch_id":"1a1251f3a80e636c4bf6cf1d2e02f8a9","schedule_id":"704d798d-40e6-4128-b7ca-ba50be800377","message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:21 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:50:32 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/send_messages/unauthorized/responds_with_unauthorized.yml
+++ b/spec/fixtures/responses/send_messages/unauthorized/responds_with_unauthorized.yml
@@ -5,21 +5,27 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/send"
     body:
       encoding: UTF-8
-      string: '{"api_key":"non-existent","messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[1]}'
+      string: '{"messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[12345]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer non-existent
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 401
       message: Unauthorized
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -35,32 +41,28 @@ http_interactions:
       X-Ratelimit-Reset:
       - ''
       X-Request-Id:
-      - b9f8ce77-4265-46a4-8010-04dad0d35c92
+      - ede47716-681c-40c8-8c3f-90cb22269092
       X-Runtime:
-      - '0.006126'
-      Content-Length:
-      - '85'
+      - '0.000632'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:23 GMT
+      - Wed, 17 Jun 2020 20:37:30 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17839-PDK
+      - cache-hhn4061-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999303.988243,VS0,VE44
+      - S1592426251.943565,VS0,VE48
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"Invalid App Group API Identifier: non-existent"}'
+      string: '{"message":"Invalid API key: non-existent"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:23 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:37:31 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/send_messages/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/send_messages/with_success/responds_with_created.yml
@@ -5,65 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/send"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[1]}'
+      string: '{"messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[12345]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"838a7c62adda8d131d694ae13ba2c5b7"
+      - W/"b9e7fd89d471f3f07bc5423aebe2ffec"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49989'
+      - '249954'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - aec47065-45d4-4fb7-a593-a4ffd110c314
+      - e2e72c50-28ca-48b1-a8a0-4f5358ee3e71
       X-Runtime:
-      - '0.013801'
-      Content-Length:
-      - '46'
+      - '0.015367'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:22 GMT
+      - Wed, 17 Jun 2020 20:37:30 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17821-PDK
+      - cache-hhn4020-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999302.923924,VS0,VE423
+      - S1592426251.662252,VS0,VE65
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"success"}'
+      string: '{"dispatch_id":"dad3e2b4166cf9902f5ce54215241a33","message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:22 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:37:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/send_messages/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/send_messages/with_success/responds_with_success_message.yml
@@ -5,65 +5,67 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/messages/send"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[1]}'
+      string: '{"messages":{"apple_push":{"alert":"hello"}},"external_user_ids":[12345]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '94'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"838a7c62adda8d131d694ae13ba2c5b7"
+      - W/"c0f33a016781b92e299866060ef19a97"
       Server:
       - nginx
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '49988'
+      - '249953'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - 864641c8-44d3-4389-84a1-e411ee44561e
+      - 27779097-2153-47ba-9dad-196e9673d913
       X-Runtime:
-      - '0.027612'
-      Content-Length:
-      - '46'
+      - '0.009393'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:22 GMT
+      - Wed, 17 Jun 2020 20:37:30 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17839-PDK
+      - cache-hhn4076-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999302.411567,VS0,VE410
+      - S1592426251.823361,VS0,VE12
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"success"}'
+      string: '{"dispatch_id":"ea0532cddfc97cd4e5767b351d6af0eb","message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:22 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:37:30 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_subscribing/subscribes_the_user.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_subscribing/subscribes_the_user.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-001","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,36 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249977'
+      - '249958'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 9e429cb2-6c63-44e8-bb25-97d23edb25d1
+      - fbac8f93-a99e-452b-b5a3-8fc91d85e232
       X-Runtime:
-      - '0.008757'
-      Content-Length:
-      - '46'
+      - '0.005479'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:46 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4035-HHN
+      - cache-hhn4062-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409586.236608,VS0,VE18
+      - S1592426156.816894,VS0,VE8
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:46 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_subscribing/subscribes_the_user.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_subscribing/subscribes_the_user.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,32 +40,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249958'
+      - '249986'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - fbac8f93-a99e-452b-b5a3-8fc91d85e232
+      - 535f2a1b-31db-456a-9932-a927c56cfbb3
       X-Runtime:
-      - '0.005479'
+      - '0.006043'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4062-HHN
+      - cache-hhn4056-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.816894,VS0,VE8
+      - S1592474588.853802,VS0,VE9
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_subscription_group_does_not_exist/returns_an_error_status.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_subscription_group_does_not_exist/returns_an_error_status.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-001","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 400
       message: Bad Request
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -31,36 +37,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249974'
+      - '249955'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 9d318398-4dbe-4fca-8bc8-fed3002af64a
+      - 285e3842-f442-4877-b5b9-5328ac36c2be
       X-Runtime:
-      - '0.013998'
-      Content-Length:
-      - '69'
+      - '0.031452'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:46 GMT
+      - Wed, 17 Jun 2020 20:35:56 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4070-HHN
+      - cache-hhn4036-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409587.847958,VS0,VE17
+      - S1592426156.132497,VS0,VE34
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:46 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:56 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_subscription_group_does_not_exist/returns_an_error_status.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_subscription_group_does_not_exist/returns_an_error_status.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -37,32 +37,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249955'
+      - '249983'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 285e3842-f442-4877-b5b9-5328ac36c2be
+      - 1e81ac78-b72f-476a-8259-70f90aa2d170
       X-Runtime:
-      - '0.031452'
+      - '0.013319'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:56 GMT
+      - Thu, 18 Jun 2020 10:03:08 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4036-HHN
+      - cache-hhn4038-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.132497,VS0,VE34
+      - S1592474588.160260,VS0,VE16
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:56 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:08 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_unsubscribing/unsubscribes_the_user.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_unsubscribing/unsubscribes_the_user.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,40 +40,40 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249957'
+      - '249985'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 34e22a6a-24dc-4731-a6f6-0c2f25c3bd03
+      - d808049c-58d0-413b-84ed-c9976614bc96
       X-Runtime:
-      - '0.006923'
+      - '0.011481'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4080-HHN
+      - cache-hhn4056-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.923539,VS0,VE9
+      - S1592474588.950706,VS0,VE15
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
+      string: '{"external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -108,32 +108,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249956'
+      - '249984'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - f258a5ba-32b0-44c9-a8af-0752305db373
+      - cf4a6c76-ff97-4790-8a24-d0febe4764c4
       X-Runtime:
-      - '0.005190'
+      - '0.010860'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:56 GMT
+      - Thu, 18 Jun 2020 10:03:08 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4072-HHN
+      - cache-hhn4056-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.022530,VS0,VE8
+      - S1592474588.057509,VS0,VE14
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:56 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:08 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/subscription_status_set/when_unsubscribing/unsubscribes_the_user.yml
+++ b/spec/fixtures/responses/subscription/subscription_status_set/when_unsubscribing/unsubscribes_the_user.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-002","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,51 +40,49 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249976'
+      - '249957'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - c59a4c1a-8e48-487a-ba11-5bac411e109b
+      - 34e22a6a-24dc-4731-a6f6-0c2f25c3bd03
       X-Runtime:
-      - '0.005244'
-      Content-Length:
-      - '46'
+      - '0.006923'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:46 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4022-HHN
+      - cache-hhn4080-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409586.449783,VS0,VE13
+      - S1592426156.923539,VS0,VE9
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:46 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-002","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"unsubscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -86,6 +90,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -100,36 +108,32 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249975'
+      - '249956'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 596f4df6-b90e-4de8-94cb-43e62b03ee7d
+      - f258a5ba-32b0-44c9-a8af-0752305db373
       X-Runtime:
-      - '0.006277'
-      Content-Length:
-      - '46'
+      - '0.005190'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:46 GMT
+      - Wed, 17 Jun 2020 20:35:56 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4023-HHN
+      - cache-hhn4072-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409587.663692,VS0,VE14
+      - S1592426156.022530,VS0,VE8
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:46 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:56 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_checking_subscribed_and_unsubscribed_user_status/returns_only_users_that_were_once_subscribed.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_checking_subscribed_and_unsubscribed_user_status/returns_only_users_that_were_once_subscribed.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-001","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,51 +40,49 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249983'
+      - '249964'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 870fe392-6e88-4d29-bb09-44abb692feee
+      - 91096806-7a98-4472-9579-3c76bc573ff5
       X-Runtime:
-      - '0.004454'
-      Content-Length:
-      - '46'
+      - '0.007539'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:44 GMT
+      - Wed, 17 Jun 2020 20:35:54 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4067-HHN
+      - cache-hhn4057-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409585.950445,VS0,VE12
+      - S1592426155.893407,VS0,VE10
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:44 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-002","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"unsubscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -86,6 +90,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -100,41 +108,37 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249982'
+      - '249963'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 653dcaaa-5c38-4e71-b65c-f0b0149638d4
+      - c73be354-985d-4931-87ad-cf9d2209067b
       X-Runtime:
-      - '0.006976'
-      Content-Length:
-      - '46'
+      - '0.005275'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:45 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4027-HHN
+      - cache-hhn4035-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409585.148598,VS0,VE54
+      - S1592426155.996364,VS0,VE8
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id%5B%5D=test-gem-001&external_id%5B%5D=test-gem-002&external_id%5B%5D=test-gem-003&subscription_group_id=0201b87a-ef6e-4410-9412-a298c4c1206d"
+    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id%5B%5D=test-user-1&external_id%5B%5D=test-user-2&external_id%5B%5D=test-user-3&subscription_group_id=ed06e19a-69b1-4f9b-a452-2db2c4e303a8"
     body:
       encoding: US-ASCII
       string: ''
@@ -144,7 +148,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -152,12 +158,16 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '105'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"693ac9a1fc6752c76edadb586c391f44"
+      - W/"1666e6b741dc1b301e4196e3bf59b6ac"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -166,40 +176,36 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249981'
+      - '249962'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - c7e25224-b577-4528-8990-43af1de7e6d9
+      - e3f99e07-d6d0-496c-b428-b97a2618faa3
       X-Runtime:
-      - '0.031761'
+      - '0.146739'
       Accept-Ranges:
       - bytes
       - bytes
       Age:
       - '0'
       - '0'
-      Content-Length:
-      - '106'
       Date:
-      - Fri, 22 Nov 2019 07:59:45 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4053-HHN
+      - cache-hhn4075-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409585.392003,VS0,VE34
+      - S1592426155.119470,VS0,VE151
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"status":{"test-gem-001":"Subscribed","test-gem-002":"Unsubscribed","test-gem-003":"unknown"},"message":"success"}'
+      string: '{"status":{"test-user-1":"Subscribed","test-user-2":"Unsubscribed","test-user-3":"unknown"},"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_checking_subscribed_and_unsubscribed_user_status/returns_only_users_that_were_once_subscribed.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_checking_subscribed_and_unsubscribed_user_status/returns_only_users_that_were_once_subscribed.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,85 +40,17 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249964'
+      - '249992'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 91096806-7a98-4472-9579-3c76bc573ff5
+      - ca3c0d06-56e9-4827-b401-464aeb2770e7
       X-Runtime:
-      - '0.007539'
+      - '0.009484'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:54 GMT
-      Via:
-      - 1.1 varnish
-      X-Served-By:
-      - cache-hhn4057-HHN
-      X-Cache:
-      - MISS
-      X-Cache-Hits:
-      - '0'
-      X-Timer:
-      - S1592426155.893407,VS0,VE10
-      Vary:
-      - Origin,Accept-Encoding
-    body:
-      encoding: ASCII-8BIT
-      string: '{"message":"success"}'
-    http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
-- request:
-    method: post
-    uri: "<BRAZE_REST_URL>/subscription/status/set"
-    body:
-      encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
-    headers:
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      User-Agent:
-      - Braze Ruby gem v0.3.3
-      Authorization:
-      - Bearer <BRAZE_REST_API_KEY>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '46'
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Content-Type:
-      - application/json
-      Etag:
-      - W/"838a7c62adda8d131d694ae13ba2c5b7"
-      Server:
-      - nginx
-      Strict-Transport-Security:
-      - max-age=0; includeSubDomains
-      - max-age=31536000; includeSubDomains
-      X-Ratelimit-Limit:
-      - '250000'
-      X-Ratelimit-Remaining:
-      - '249963'
-      X-Ratelimit-Reset:
-      - '1592427600'
-      X-Request-Id:
-      - c73be354-985d-4931-87ad-cf9d2209067b
-      X-Runtime:
-      - '0.005275'
-      Accept-Ranges:
-      - bytes
-      Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:06 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
@@ -128,17 +60,85 @@ http_interactions:
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426155.996364,VS0,VE8
+      - S1592474587.848648,VS0,VE13
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:06 GMT
+- request:
+    method: post
+    uri: "<BRAZE_REST_URL>/subscription/status/set"
+    body:
+      encoding: UTF-8
+      string: '{"external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
+    headers:
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json
+      Etag:
+      - W/"838a7c62adda8d131d694ae13ba2c5b7"
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=0; includeSubDomains
+      - max-age=31536000; includeSubDomains
+      X-Ratelimit-Limit:
+      - '250000'
+      X-Ratelimit-Remaining:
+      - '249991'
+      X-Ratelimit-Reset:
+      - '1592478000'
+      X-Request-Id:
+      - 619fbe14-57be-4e68-99bc-8dfd519aeb3f
+      X-Runtime:
+      - '0.016383'
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Thu, 18 Jun 2020 10:03:06 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-hhn4074-HHN
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1592474587.944065,VS0,VE19
+      Vary:
+      - Origin,Accept-Encoding
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"success"}'
+    http_version: 
+  recorded_at: Thu, 18 Jun 2020 10:03:06 GMT
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id%5B%5D=test-user-1&external_id%5B%5D=test-user-2&external_id%5B%5D=test-user-3&subscription_group_id=ed06e19a-69b1-4f9b-a452-2db2c4e303a8"
+    uri: "<BRAZE_REST_URL>/subscription/status/get?external_id%5B%5D=test-user-1&external_id%5B%5D=test-user-2&external_id%5B%5D=test-user-3&subscription_group_id=ed06e19a-69b1-4f9b-a452-2db2c4e303a8"
     body:
       encoding: US-ASCII
       string: ''
@@ -160,8 +160,6 @@ http_interactions:
     headers:
       Connection:
       - keep-alive
-      Content-Length:
-      - '105'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -176,13 +174,13 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249962'
+      - '249990'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - e3f99e07-d6d0-496c-b428-b97a2618faa3
+      - dec0761d-28e5-4757-abc2-281d20452d12
       X-Runtime:
-      - '0.146739'
+      - '0.274580'
       Accept-Ranges:
       - bytes
       - bytes
@@ -190,22 +188,24 @@ http_interactions:
       - '0'
       - '0'
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4075-HHN
+      - cache-hhn4071-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426155.119470,VS0,VE151
+      - S1592474587.060881,VS0,VE279
       Vary:
       - Origin,Accept-Encoding
+      Transfer-Encoding:
+      - chunked
     body:
       encoding: ASCII-8BIT
       string: '{"status":{"test-user-1":"Subscribed","test-user-2":"Unsubscribed","test-user-3":"unknown"},"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_group_does_not_exist/returns_an_error.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_group_does_not_exist/returns_an_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -37,40 +37,40 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249961'
+      - '249989'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 9755c1e8-a2f0-4544-846a-7af38c68cc82
+      - a79133bc-a760-4a22-a42f-26dd5961f2f7
       X-Runtime:
-      - '0.056532'
+      - '0.034508'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4051-HHN
+      - cache-hhn4058-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426155.381280,VS0,VE60
+      - S1592474587.426453,VS0,VE37
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"non-existing-subscription-group","subscription_state":"unsubscribed"}'
+      string: '{"external_id":"test-user-2","subscription_group_id":"non-existing-subscription-group","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -102,37 +102,37 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249960'
+      - '249988'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 3634daac-e2da-487f-bcb6-21920f1584b3
+      - 264b0fb1-5574-40fa-ad46-e6866e1694d6
       X-Runtime:
-      - '0.041838'
+      - '0.058967'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4059-HHN
+      - cache-hhn4040-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.540854,VS0,VE44
+      - S1592474588.556657,VS0,VE62
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id=test-user-1&subscription_group_id=non-existing-subscription-group"
+    uri: "<BRAZE_REST_URL>/subscription/status/get?external_id=test-user-1&subscription_group_id=non-existing-subscription-group"
     body:
       encoding: US-ASCII
       string: ''
@@ -167,33 +167,33 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249959'
+      - '249987'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 4cc890fd-7070-403b-85b6-0f1565046779
+      - a22e0245-a827-48c5-9525-22e54a820782
       X-Runtime:
-      - '0.035309'
+      - '0.023071'
       Accept-Ranges:
       - bytes
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:55 GMT
+      - Thu, 18 Jun 2020 10:03:07 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4031-HHN
+      - cache-hhn4072-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426156.680642,VS0,VE38
+      - S1592474588.708248,VS0,VE27
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:07 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_group_does_not_exist/returns_an_error.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_status_get/when_group_does_not_exist/returns_an_error.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-001","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"non-existing-subscription-group","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 400
       message: Bad Request
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -31,51 +37,49 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249980'
+      - '249961'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 620af52d-d528-46bd-bc42-8e658850ff56
+      - 9755c1e8-a2f0-4544-846a-7af38c68cc82
       X-Runtime:
-      - '0.011493'
-      Content-Length:
-      - '69'
+      - '0.056532'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:45 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4035-HHN
+      - cache-hhn4051-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409586.594248,VS0,VE57
+      - S1592426155.381280,VS0,VE60
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-002","subscription_group_id":"non-existing-subscription-group","subscription_state":"unsubscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"non-existing-subscription-group","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -83,6 +87,10 @@ http_interactions:
       code: 400
       message: Bad Request
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -94,41 +102,37 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249979'
+      - '249960'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 1dbbe62d-e251-46ac-b511-9e435f790a96
+      - 3634daac-e2da-487f-bcb6-21920f1584b3
       X-Runtime:
-      - '0.009396'
-      Content-Length:
-      - '69'
+      - '0.041838'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:45 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4061-HHN
+      - cache-hhn4059-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409586.826897,VS0,VE15
+      - S1592426156.540854,VS0,VE44
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:45 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id=test-gem-001&subscription_group_id=non-existing-subscription-group"
+    uri: "<BRAZE_REST_URL>/subscription/status/get?api_key=<BRAZE_REST_API_KEY>&external_id=test-user-1&subscription_group_id=non-existing-subscription-group"
     body:
       encoding: US-ASCII
       string: ''
@@ -138,7 +142,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -146,6 +152,10 @@ http_interactions:
       code: 400
       message: Bad Request
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -157,37 +167,33 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249978'
+      - '249959'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - f79731f9-3440-47dc-871c-6349fbaf28ea
+      - 4cc890fd-7070-403b-85b6-0f1565046779
       X-Runtime:
-      - '0.009930'
+      - '0.035309'
       Accept-Ranges:
       - bytes
       - bytes
-      Content-Length:
-      - '69'
       Date:
-      - Fri, 22 Nov 2019 07:59:46 GMT
+      - Wed, 17 Jun 2020 20:35:55 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4051-HHN
+      - cache-hhn4031-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409586.039550,VS0,VE13
+      - S1592426156.680642,VS0,VE38
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"Invalid subscription group ID"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:46 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:55 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_user_status/returns_subscription_groups_and_status_for_every_group.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_user_status/returns_subscription_groups_and_status_for_every_group.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
+      string: '{"external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -40,40 +40,40 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249967'
+      - '249995'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 9a2653af-a41b-4085-9389-a1151db08c6e
+      - 3c0417c1-397b-4f71-b60c-c2a2082a435a
       X-Runtime:
-      - '0.007510'
+      - '0.012552'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:54 GMT
+      - Thu, 18 Jun 2020 10:03:06 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4040-HHN
+      - cache-hhn4023-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426154.270505,VS0,VE11
+      - S1592474586.184983,VS0,VE16
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:06 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
+      string: '{"external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
@@ -108,34 +108,34 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249966'
+      - '249994'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - ce75c931-b122-4aad-92c3-6db310c24ad4
+      - b49b0519-bb0a-4e16-b9c0-9d5af6fee340
       X-Runtime:
-      - '0.008743'
+      - '0.012962'
       Accept-Ranges:
       - bytes
       Date:
-      - Wed, 17 Jun 2020 20:35:54 GMT
+      - Thu, 18 Jun 2020 10:03:06 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4073-HHN
+      - cache-hhn4057-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426154.373418,VS0,VE11
+      - S1592474586.279449,VS0,VE16
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:06 GMT
 - request:
     method: get
     uri: "<BRAZE_REST_URL>/subscription/user/status?external_id%5B%5D=test-user-1&external_id%5B%5D=test-user-2&external_id%5B%5D=test-user-3"
@@ -176,13 +176,13 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249965'
+      - '249993'
       X-Ratelimit-Reset:
-      - '1592427600'
+      - '1592478000'
       X-Request-Id:
-      - 7cf13d94-44f3-4c96-afa6-f1bc1737050f
+      - 2c909898-af08-4996-b063-cccd07cbee21
       X-Runtime:
-      - '0.274424'
+      - '0.291483'
       Accept-Ranges:
       - bytes
       - bytes
@@ -190,22 +190,22 @@ http_interactions:
       - '0'
       - '0'
       Date:
-      - Wed, 17 Jun 2020 20:35:54 GMT
+      - Thu, 18 Jun 2020 10:03:06 GMT
       Via:
       - 1.1 varnish
       X-Served-By:
-      - cache-hhn4055-HHN
+      - cache-hhn4039-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1592426154.495497,VS0,VE278
+      - S1592474586.385788,VS0,VE300
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"users":[{"email":"test-user-1@test.com","phone":null,"external_id":"test-user-1","subscription_groups":[{"id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","name":"test-subscription-group","channel":"email","status":"Subscribed"}]},{"email":"test-user-2@test.com","phone":null,"external_id":"test-user-2","subscription_groups":[{"id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","name":"test-subscription-group","channel":"email","status":"Unsubscribed"}]},{"email":"test-user-3@test.com","phone":null,"external_id":"test-user-3","subscription_groups":[]}],"total_count":3,"message":"success"}'
     http_version: 
-  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
+  recorded_at: Thu, 18 Jun 2020 10:03:06 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_user_status/returns_subscription_groups_and_status_for_every_group.yml
+++ b/spec/fixtures/responses/subscription/when_getting_subscription_group_statuses/subscription_user_status/returns_subscription_groups_and_status_for_every_group.yml
@@ -5,14 +5,16 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-001","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"subscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-1","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"subscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -20,6 +22,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,51 +40,49 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249986'
+      - '249967'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - a5ba5ff1-a40c-471d-af9f-05cbf4b35e9c
+      - 9a2653af-a41b-4085-9389-a1151db08c6e
       X-Runtime:
-      - '0.010196'
-      Content-Length:
-      - '46'
+      - '0.007510'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:44 GMT
+      - Wed, 17 Jun 2020 20:35:54 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4074-HHN
+      - cache-hhn4040-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409584.278113,VS0,VE18
+      - S1592426154.270505,VS0,VE11
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:44 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
 - request:
     method: post
     uri: "<BRAZE_REST_URL>/subscription/status/set"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-gem-002","subscription_group_id":"0201b87a-ef6e-4410-9412-a298c4c1206d","subscription_state":"unsubscribed"}'
+      string: '{"api_key":"<BRAZE_REST_API_KEY>","external_id":"test-user-2","subscription_group_id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","subscription_state":"unsubscribed"}'
     headers:
       Content-Type:
       - application/json
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -86,6 +90,10 @@ http_interactions:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -100,41 +108,37 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249985'
+      - '249966'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 7721b688-c1f0-423c-bb35-b967dd92bd21
+      - ce75c931-b122-4aad-92c3-6db310c24ad4
       X-Runtime:
-      - '0.007053'
-      Content-Length:
-      - '46'
+      - '0.008743'
       Accept-Ranges:
       - bytes
       Date:
-      - Fri, 22 Nov 2019 07:59:44 GMT
+      - Wed, 17 Jun 2020 20:35:54 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4067-HHN
+      - cache-hhn4073-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409584.489346,VS0,VE53
+      - S1592426154.373418,VS0,VE11
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:44 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
 - request:
     method: get
-    uri: "<BRAZE_REST_URL>/subscription/user/status?api_key=<BRAZE_REST_API_KEY>&external_id%5B%5D=test-gem-001&external_id%5B%5D=test-gem-002&external_id%5B%5D=test-gem-003"
+    uri: "<BRAZE_REST_URL>/subscription/user/status?external_id%5B%5D=test-user-1&external_id%5B%5D=test-user-2&external_id%5B%5D=test-user-3"
     body:
       encoding: US-ASCII
       string: ''
@@ -144,7 +148,9 @@ http_interactions:
       Accept:
       - application/json
       User-Agent:
-      - Braze Ruby gem v0.2.2
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
   response:
@@ -152,12 +158,16 @@ http_interactions:
       code: 200
       message: OK
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '233'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
       - application/json
       Etag:
-      - W/"c07db3553c76472c579e5181e73ec603"
+      - W/"73587e244e20caff598bc8613a738936"
       Server:
       - nginx
       Strict-Transport-Security:
@@ -166,42 +176,36 @@ http_interactions:
       X-Ratelimit-Limit:
       - '250000'
       X-Ratelimit-Remaining:
-      - '249984'
+      - '249965'
       X-Ratelimit-Reset:
-      - '1574409600'
+      - '1592427600'
       X-Request-Id:
-      - 49cde848-ee57-46f7-9692-5023fb8be287
+      - 7cf13d94-44f3-4c96-afa6-f1bc1737050f
       X-Runtime:
-      - '0.024667'
+      - '0.274424'
       Accept-Ranges:
       - bytes
       - bytes
       Age:
       - '0'
       - '0'
-      Content-Length:
-      - '228'
       Date:
-      - Fri, 22 Nov 2019 07:59:44 GMT
+      - Wed, 17 Jun 2020 20:35:54 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-hhn4043-HHN
+      - cache-hhn4055-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1574409585.753149,VS0,VE28
+      - S1592426154.495497,VS0,VE278
       Vary:
       - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"users":[{"email":null,"phone":null,"external_id":"test-gem-001","subscription_groups":[{"id":"0201b87a-ef6e-4410-9412-a298c4c1206d","name":"Test
-        Subscription Group","channel":"email","status":"Subscribed"}]},{"email":null,"phone":null,"external_id":"test-gem-002","subscription_groups":[{"id":"0201b87a-ef6e-4410-9412-a298c4c1206d","name":"Test
-        Subscription Group","channel":"email","status":"Unsubscribed"}]},{"email":null,"phone":null,"external_id":"test-gem-003","subscription_groups":[]}],"total_count":3,"message":"success"}'
+      string: '{"users":[{"email":"test-user-1@test.com","phone":null,"external_id":"test-user-1","subscription_groups":[{"id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","name":"test-subscription-group","channel":"email","status":"Subscribed"}]},{"email":"test-user-2@test.com","phone":null,"external_id":"test-user-2","subscription_groups":[{"id":"ed06e19a-69b1-4f9b-a452-2db2c4e303a8","name":"test-subscription-group","channel":"email","status":"Unsubscribed"}]},{"email":"test-user-3@test.com","phone":null,"external_id":"test-user-3","subscription_groups":[]}],"total_count":3,"message":"success"}'
     http_version: 
-  recorded_at: Fri, 22 Nov 2019 07:59:44 GMT
+  recorded_at: Wed, 17 Jun 2020 20:35:54 GMT
 recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/track_users/unauthorized/responds_with_unauthorized.yml
+++ b/spec/fixtures/responses/track_users/unauthorized/responds_with_unauthorized.yml
@@ -5,23 +5,29 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/track"
     body:
       encoding: UTF-8
-      string: '{"api_key":"non-existent","attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
+      string: '{"attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
         00:00:00 -0500"}],"purchases":[{"external_id":1,"product_id":1,"time":"2019-02-15
         00:00:00 -0500","currency":"CAD","price":1.0}]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer non-existent
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 401
       message: Unauthorized
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
       Cache-Control:
       - no-cache
       Content-Type:
@@ -31,38 +37,34 @@ http_interactions:
       Strict-Transport-Security:
       - max-age=0; includeSubDomains
       X-Ratelimit-Limit:
-      - '0'
+      - ''
       X-Ratelimit-Remaining:
-      - '0'
+      - ''
       X-Ratelimit-Reset:
-      - '1524002400'
+      - ''
       X-Request-Id:
-      - 7089825e-0390-4b95-b471-3c096e1df0e6
+      - 455108aa-0cf4-438f-8d27-489896ca716b
       X-Runtime:
-      - '0.006623'
-      Content-Length:
-      - '85'
+      - '0.001106'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:08 GMT
+      - Wed, 17 Jun 2020 20:31:42 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17844-PDK
+      - cache-hhn4044-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999288.903112,VS0,VE193
+      - S1592425903.848710,VS0,VE4
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
-      string: '{"message":"Invalid App Group API Identifier: non-existent"}'
+      string: '{"message":"Invalid API key: non-existent"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:08 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:31:42 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/track_users/with_success/responds_with_created.yml
+++ b/spec/fixtures/responses/track_users/with_success/responds_with_created.yml
@@ -5,23 +5,29 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/track"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
+      string: '{"attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
         00:00:00 -0500"}],"purchases":[{"external_id":1,"product_id":1,"time":"2019-02-15
         00:00:00 -0500","currency":"CAD","price":1.0}]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,38 +40,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '50000'
+      - '250000'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - af452a7f-9be9-417d-b9d5-2c4db3de274d
+      - 2e7a73fc-7efe-4c04-b837-c696cb10735a
       X-Runtime:
-      - '0.020310'
-      Content-Length:
-      - '85'
+      - '0.007710'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:07 GMT
+      - Wed, 17 Jun 2020 20:31:42 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17837-PDK
+      - cache-hhn4030-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999287.293178,VS0,VE220
+      - S1592425903.632582,VS0,VE10
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"attributes_processed":1,"events_processed":1,"purchases_processed":1,"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:07 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:31:42 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/responses/track_users/with_success/responds_with_success_message.yml
+++ b/spec/fixtures/responses/track_users/with_success/responds_with_success_message.yml
@@ -5,23 +5,29 @@ http_interactions:
     uri: "<BRAZE_REST_URL>/users/track"
     body:
       encoding: UTF-8
-      string: '{"api_key":"<BRAZE_REST_API_KEY>","attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
+      string: '{"attributes":[{"external_id":1,"foo":"bar"}],"events":[{"external_id":1,"name":"baz","time":"2019-02-15
         00:00:00 -0500"}],"purchases":[{"external_id":1,"product_id":1,"time":"2019-02-15
         00:00:00 -0500","currency":"CAD","price":1.0}]}'
     headers:
-      User-Agent:
-      - Faraday v0.14.0
       Content-Type:
       - application/json
+      Accept:
+      - application/json
+      User-Agent:
+      - Braze Ruby gem v0.3.3
+      Authorization:
+      - Bearer <BRAZE_REST_API_KEY>
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
   response:
     status:
       code: 201
       message: Created
     headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '85'
       Cache-Control:
       - max-age=0, private, must-revalidate
       Content-Type:
@@ -34,38 +40,34 @@ http_interactions:
       - max-age=0; includeSubDomains
       - max-age=31536000; includeSubDomains
       X-Ratelimit-Limit:
-      - '50000'
+      - '250000'
       X-Ratelimit-Remaining:
-      - '50000'
+      - '250000'
       X-Ratelimit-Reset:
-      - '1524002400'
+      - '1592427600'
       X-Request-Id:
-      - e810e390-4c31-49ac-abd4-5b1151cc3c33
+      - 75dc3ac0-d4d2-4278-89d0-b29e540dc719
       X-Runtime:
-      - '0.012176'
-      Content-Length:
-      - '85'
+      - '0.008741'
       Accept-Ranges:
       - bytes
       Date:
-      - Tue, 17 Apr 2018 21:08:07 GMT
+      - Wed, 17 Jun 2020 20:31:42 GMT
       Via:
       - 1.1 varnish
-      Connection:
-      - keep-alive
       X-Served-By:
-      - cache-pdk17824-PDK
+      - cache-hhn4063-HHN
       X-Cache:
       - MISS
       X-Cache-Hits:
       - '0'
       X-Timer:
-      - S1523999288.612820,VS0,VE214
+      - S1592425903.749169,VS0,VE11
       Vary:
-      - Accept-Encoding
+      - Origin,Accept-Encoding
     body:
       encoding: ASCII-8BIT
       string: '{"attributes_processed":1,"events_processed":1,"purchases_processed":1,"message":"success"}'
     http_version: 
-  recorded_at: Tue, 17 Apr 2018 21:08:07 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 17 Jun 2020 20:31:42 GMT
+recorded_with: VCR 5.0.0

--- a/spec/integrations/campaigns_spec.rb
+++ b/spec/integrations/campaigns_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe 'campaigns' do
   describe 'trigger_send' do
     it 'sends an email', vcr: true do
       response = api.trigger_campaign_send(
-        campaign_id: '69e9b681-779c-4b4c-b6b8-cd74b17d21d2',
+        campaign_id: 'd8b73da7-0b7c-fc72-1d80-e59c7f20f0d3',
         recipients: [
-          external_user_id: 132404,
+          external_user_id: 12345,
           trigger_properties: {first_name: 'John'}
         ]
       )
+
+      expect(response.success?).to eq(true)
     end
   end
 end

--- a/spec/integrations/canvas_spec.rb
+++ b/spec/integrations/canvas_spec.rb
@@ -6,12 +6,14 @@ RSpec.describe 'canvas' do
   describe 'trigger_send' do
     it 'sends a canvas', vcr: true do
       response = api.trigger_canvas_send(
-        canvas_id: 'dc23ade4-e970-0c52-81bc-b369f64f533d',
+        canvas_id: '70a7fb99-cbcb-451a-8224-5f8b8c63e03f',
         recipients: [
-          external_user_id: 132404,
+          external_user_id: 12345,
           canvas_entry_properties: {first_name: 'John'}
         ]
       )
+
+      expect(response.success?).to eq(true)
     end
   end
 

--- a/spec/integrations/delete_users_spec.rb
+++ b/spec/integrations/delete_users_spec.rb
@@ -16,6 +16,7 @@ describe 'delete users' do
 
     it 'responds with success message' do
       expect(JSON.parse(delete_users.body)).to include(
+          'deleted' => 3,
           'message' => 'success'
         )
     end

--- a/spec/integrations/email_sync_spec.rb
+++ b/spec/integrations/email_sync_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 RSpec.describe 'email sync' do
   describe 'unsubscribes' do
     it 'responds with unsubscribed emails', vcr: true do
-      response = api.email_unsubscribes(start_date: '2019-03-20', end_date: '2019-03-25')
+      response = api.email_unsubscribes(start_date: '2020-06-17', end_date: '2020-06-18')
       emails = JSON.parse(response.body)['emails']
 
       expect(emails.size).to eq(1)
-      expect(emails.first['email']).to eq('wojtek@test.com')
+      expect(emails.first['email']).to eq('example@123.com')
     end
 
     it 'responds with empty array when no unsubscribes', vcr: true do

--- a/spec/integrations/export_users_spec.rb
+++ b/spec/integrations/export_users_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 describe 'export users' do
   context 'by ids' do
-    subject(:export_users) { api.export_users(external_ids: [1]) }
+    subject(:export_users) { api.export_users(external_ids: [12345]) }
 
     context 'with success', :vcr do
       it 'responds with created' do
@@ -15,7 +15,7 @@ describe 'export users' do
 
   context 'by segment' do
     context 'with success', :vcr do
-      let(:segment_id) { braze_test_segment }
+      let(:segment_id) { "3aca937b-9bbc-4e42-9370-05e411967b2b" }
 
       subject(:export_users) do
         api.export_users(segment_id: segment_id, callback_endpoint: 'https://example.com')

--- a/spec/integrations/identify_users_spec.rb
+++ b/spec/integrations/identify_users_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'identify users' do
-  let(:user) { { external_id: 400, user_alias: { alias_name: 'abc', alias_label: 'foo' } } }
+  let(:user) { { external_id: 12345, user_alias: { alias_name: 'abc', alias_label: 'foo' } } }
 
   subject(:identify_users) do
     api.identify_users(aliases_to_identify: [user])

--- a/spec/integrations/list_segments_spec.rb
+++ b/spec/integrations/list_segments_spec.rb
@@ -11,7 +11,7 @@ describe 'list segments' do
     end
 
     it 'responds with a list of segments' do
-      expect(segments.count).to be 13
+      expect(segments.count).to be 6
     end
 
     def segments

--- a/spec/integrations/schedule_messages_spec.rb
+++ b/spec/integrations/schedule_messages_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 
 describe 'schedule messages' do
-  let(:user_ids) { [1] }
+  let(:user_ids) { [12345] }
+  let(:test_time) { "2020-08-07T00:00:00+02:00" }
   let(:messages) { build(:messages) }
 
   subject(:schedule_messages) do

--- a/spec/integrations/send_messages_spec.rb
+++ b/spec/integrations/send_messages_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'send messages' do
-  let(:user_ids) { [1] }
+  let(:user_ids) { [12345] }
   let(:messages) { build(:messages) }
 
   subject(:send_messages) do
@@ -17,6 +17,7 @@ describe 'send messages' do
 
     it 'responds with success message' do
       expect(JSON.parse(send_messages.body)).to eq(
+          'dispatch_id' => "ea0532cddfc97cd4e5767b351d6af0eb",
           'message' => 'success'
         )
     end

--- a/spec/integrations/subscription_spec.rb
+++ b/spec/integrations/subscription_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 
 RSpec.describe 'subscription', vcr: true do
-  let(:subscription_group_id) { '0201b87a-ef6e-4410-9412-a298c4c1206d' }
-  let(:subscribed_user) { 'test-gem-001' }
-  let(:unsubscribed_user) { 'test-gem-002' }
-  let(:never_subscribed_user) { 'test-gem-003' }
+  let(:subscription_group_id) { 'ed06e19a-69b1-4f9b-a452-2db2c4e303a8' }
+  let(:subscribed_user) { 'test-user-1' }
+  let(:unsubscribed_user) { 'test-user-2' }
+  let(:never_subscribed_user) { 'test-user-3' }
 
   context 'when getting subscription group statuses' do
     let(:json_response) { JSON.parse(response.body) }
@@ -83,9 +83,9 @@ RSpec.describe 'subscription', vcr: true do
           expect(json_response).to eq(
             'message' => 'success',
             'status' => {
-              'test-gem-001' => 'Subscribed',
-              'test-gem-002' => 'Unsubscribed',
-              'test-gem-003' => 'unknown'
+              'test-user-1' => 'Subscribed',
+              'test-user-2' => 'Unsubscribed',
+              'test-user-3' => 'unknown'
             }
           )
         end

--- a/spec/integrations/track_users_spec.rb
+++ b/spec/integrations/track_users_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 describe 'track users' do
   let(:attributes) { [build(:attribute)] }
+  let(:test_time) { Time.parse('2019-02-15 00:00:00 -0500') }
   let(:events) { [build(:event, time: test_time)] }
   let(:purchases) { [build(:purchase, time: test_time)] }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,19 +15,11 @@ BRAZE_REST_API_KEY = ENV.fetch('BRAZE_REST_API_KEY', 'test')
 BRAZE_REST_URL = ENV.fetch('BRAZE_REST_URL', 'https://rest.iad-03.braze.com')
 
 RSpec.configure do |config|
-  def test_time
-    Time.parse('2019-02-15 00:00:00 -0500')
-  end
-
   def braze_rest_api_key
     BRAZE_REST_API_KEY
   end
 
   def braze_rest_url
     BRAZE_REST_URL
-  end
-
-  def braze_test_segment
-    'a8fde797-4c44-4406-8e6c-5850d323f169'
   end
 end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -9,7 +9,9 @@ VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/responses'
 
   config.default_cassette_options = {
-    match_requests_on: [:method, :uri, :body]
+    match_requests_on: [:method, :uri, :body],
+    record: :once,
+    allow_unused_http_interactions: false
   }
 
   config.configure_rspec_metadata!


### PR DESCRIPTION
* set api_key on Authorization headers by passing it as mandatory argument like
  braze_url
* re-record all the VCR request with new requests

As of May 2020, Braze has changed how we read API keys to be more
secure. Now API keys must be passed as a request header.
Braze will continue to support the api_key being passed through the
request body and URL parameters, but will eventually be sunset. Please
update your API calls accordingly.